### PR TITLE
Make observability optional.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 on:
   push:
+    tags-ignore:
+      - v1
+      - v2
 
 jobs:
     run-weaviate-local-k8s-basic:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
               values-override: ${{ env.VALUES_OVERRIDE }}
               enable-backup: ${{ env.ENABLE_BACKUP }}
               values-inline: ${{ env.VALUES_INLINE }}
+              observability: 'true'
         - name: Check the configured values
           run: |
               replicas=$(kubectl get sts weaviate -n weaviate -o=jsonpath="{.spec.replicas}")
@@ -90,6 +91,16 @@ jobs:
                       exit 1
                   fi
               done
+              error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9091/metrics)
+              if [[ "$error" -ne 200 ]]; then
+                echo "Error: Prometheus is not listening, returned $error"
+                exit 1
+              fi
+              error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/)
+              if [[ "$error" -ne 200 ]]; then
+                echo "Error: Grafana is not listening, returned $error"
+                exit 1
+              fi
               env_value=$(kubectl get sts weaviate -n weaviate -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ASYNC_INDEXING")].value}')
               if [[ "$env_value" != "true" ]]; then
                   echo "Error: env.ASYNC_INDEXING is not equal to true. Found $env_value"

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Configure either Weaviate Statefulset should be removed'
     required: false
     default: 'false'
+  observability:
+    description: 'Enable observability stack'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -80,6 +84,7 @@ runs:
         S3_OFFLOAD: ${{ inputs.s3-offload }}
         DELETE_STS: ${{ inputs.delete-sts }}
         VALUES_INLINE: ${{ inputs.values-inline }}
+        OBSERVABILITY: ${{ inputs.observability }}
       run: ${{ github.action_path }}/local-k8s.sh $OPERATION
     - name: Retrieve weaviate logs
       shell: bash


### PR DESCRIPTION
The observability stack takes on resources, when
running in a github runner. For that reason we can't default to true, as it might impact in the test results. We need to be careful when we enable it.
This PR makes the local execution via local-k8s.sh running with observability by default, but it
disables it when running it via Github Actions.