### PR TITLE
Decouple applying the service from waiting for it.

### DIFF
--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -97,6 +97,7 @@ function upgrade() {
     kubectl -n weaviate rollout status statefulset weaviate
     port_forward_to_weaviate
     wait_weaviate
+    wait_for_other_services
 
     # Check if Weaviate is up
     wait_for_all_healthy_nodes $REPLICAS


### PR DESCRIPTION
As we need to wait independently for Weaviate service to start, it's better to wait for other optional services after that point and use that time to leave them start up. Otherwise we increase the deploying time.