### PR TITLE
Wait for port to open during setup

### DIFF
--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -178,13 +178,13 @@ EOF
 
     # Wait for Weaviate to be up
     TIMEOUT=$(get_timeout)
-    for i in {1..10}; do
+    for i in {1..40}; do
         if kubectl get sts weaviate -n weaviate -o jsonpath='{.status.readyReplicas}' | grep -q "^${REPLICAS}$"; then
             echo_green "setup # Found readyReplicas status"
             break
         fi
         echo_green "setup # Waiting 20s for readyReplicas status to be available"
-        sleep 20
+        sleep 5
     done
     echo_green "setup # Waiting (with timeout=$TIMEOUT) for Weaviate $REPLICAS node cluster to be ready"
     kubectl wait sts/weaviate -n weaviate --for jsonpath='{.status.readyReplicas}'=${REPLICAS} --timeout=${TIMEOUT}

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -30,7 +30,7 @@ S3_OFFLOAD=${S3_OFFLOAD:-"false"}
 HELM_BRANCH=${HELM_BRANCH:-""}
 VALUES_INLINE=${VALUES_INLINE:-""}
 DELETE_STS=${DELETE_STS:-"false"}
-REPLICAS=${REPLICAS:-3}
+REPLICAS=${REPLICAS:-1}
 OBSERVABILITY=${OBSERVABILITY:-"true"}
 PROMETHEUS_PORT=9091
 GRAFANA_PORT=3000
@@ -102,7 +102,7 @@ function upgrade() {
     # Wait for Weaviate to be up
     TIMEOUT=$(get_timeout)
     echo_green "upgrade # Waiting (with timeout=$TIMEOUT) for Weaviate $REPLICAS node cluster to be ready"
-    kubectl wait sts/weaviate -n weaviate --for jsonpath='{.status.readyReplicas}'=$REPLICAS --timeout=$TIMEOUT
+    kubectl wait sts/weaviate -n weaviate --for jsonpath='{.status.readyReplicas}'=${REPLICAS} --timeout=${TIMEOUT}
     echo_green "upgrade # Waiting for rollout upgrade to be over"
     kubectl -n weaviate rollout status statefulset weaviate
     port_forward_to_weaviate $REPLICAS

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -178,8 +178,7 @@ EOF
 
     # Wait for Weaviate to be up
     TIMEOUT=$(get_timeout)
-        for i in {1..10}; do
-
+    for i in {1..10}; do
         if kubectl get sts weaviate -n weaviate -o jsonpath='{.status.readyReplicas}' | grep -q "^${REPLICAS}$"; then
             echo_green "setup # Found readyReplicas status"
             break


### PR DESCRIPTION
Setup can fail during the readReplicas check, because the test program will error if the port is not available.  This patch adds a wait loop for the port, so the ready check will soft fail, and wait for the replicas