### PR TITLE
Add prometheus_monitoring_group when observatility=true.

### DIFF
--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -444,7 +444,10 @@ function generate_helm_values() {
     fi
 
     if [[ $OBSERVABILITY == "true" ]]; then
-        helm_values="${helm_values} --set serviceMonitor.enabled=true"
+        # Add extra metrics monitoring options
+        helm_values="${helm_values} --set serviceMonitor.enabled=true \
+                            --set env.PROMETHEUS_MONITORING_GROUP=true \
+                            --set env.PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY=true"
     fi
 
     if [[ $DYNAMIC_USERS == "true" ]]; then


### PR DESCRIPTION
The PROMETHEUS_OBSERVABILITY_GROUP was missing from enabling, so it was added when OBSERVABILITY is true, to reduce impact in performance due to the metrics calculation.