### PR TITLE
Mention to check port in unhealthy error

### DIFF
--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -254,7 +254,7 @@ function wait_for_all_healthy_nodes() {
             if [ "$(is_node_healthy "$node")" == "true" ]; then
                 healthy_nodes=$((healthy_nodes+1))
             else
-                echo_yellow "Weaviate node $node is not healthy"
+                echo_yellow "Weaviate node $node is not healthy (check that no other process is using port $WEAVIATE_PORT)"
             fi
         done
 


### PR DESCRIPTION
Hit this error and thought it might be helpful to mention in the error message that the most common cause is that there's another process running that's using port 8080 (eg a leftover docker compose)