### PR TITLE
Add support for model2vec and transformers based model2vec.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         WEAVIATE_GRPC_PORT: '50052'
         HELM_BRANCH: 'main'
         S3_OFFLOAD: 'true'
-        MODULES: 'text2vec-contextionary'
+        MODULES: 'text2vec-model2vec'
         ENABLE_BACKUP: 'true'
         RBAC: 'true'
         OIDC: 'true'
@@ -268,12 +268,12 @@ jobs:
     run-weaviate-local-k8s-with-module:
       needs: get-latest-weaviate-version
       runs-on: ubuntu-latest
-      name: Invoke weaviate-local-k8s action with text2vec-contextionary module
+      name: Invoke weaviate-local-k8s action with text2vec-contextionary and model2vecmodule
       env:
         WORKERS: '2'
         REPLICAS: '3'
         WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
-        MODULES: 'text2vec-contextionary'
+        MODULES: 'text2vec-contextionary,text2vec-model2vec'
       steps:
         - name: Checkout repository
           uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ This GitHub composite action allows you to deploy Weaviate to a local Kubernetes
 - **replicas**: The number of replicas for Weaviate. (Optional, default: '3')
 - **weaviate-version**: The version of Weaviate to deploy. (Optional, default: 'latest')
 - **helm-branch**: The branch of the Helm chart repository to use. If not specified, then the latest published Helm chart for weaviate/weaviate will used. (Optional, default: '')
-- **modules**: The vectorizer/modules that will be started up along with Weaviate. Consists on a comma-separated list of modules. The list of supported modules can be found [here](https://weaviate.io/developers/weaviate/modules)
+- **modules**: Comma-separated list of Weaviate modules to enable. See the [official modules documentation](https://weaviate.io/developers/weaviate/modules) for available options.
+
+  **Custom modules supported:**
+  - `text2vec-transformers-model2vec`: Uses a static model2vec image to deploy a transformers model. This option provides faster performance but lower embedding quality compared to standard transformers modules.
 - **delete-sts**: Allows deleting the Weaviate statefulset before perfoming an upgrade operation. Required for the upgrade from non-RAFT (pre-1.25) to RAFT (1.25)
 - **enable-backup**: When set to true it configures Weaviate to support S3 backups using MinIO. Refer to the [backup and restore](https://weaviate.io/developers/weaviate/configuration/backups#) documentation for more information.
 - **s3-offload**: When set to true it configures Weaviate to support S3 tenant offloading using MinIO. This functionality is only supported in Weaviate 1.26

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -56,7 +56,10 @@ Environment Variables:
 
   Deployment Options:
     MODULES            Comma-separated list of Weaviate modules to enable (default: "")
-                      Available modules: https://weaviate.io/developers/weaviate/model-providers
+                       Available modules: https://weaviate.io/developers/weaviate/model-providers
+                       Custom modules:
+                         * text2vec-transformers-model2vec: Configures a transformers module which uses
+                           a model2vec image to scrifice quality for speed.
     HELM_BRANCH        Specific branch of weaviate-helm to use (default: "")
     VALUES_INLINE      Additional Helm values to pass inline (default: "")
     DELETE_STS         Delete StatefulSet during upgrade (default: false)
@@ -474,6 +477,12 @@ function generate_helm_values() {
         # Splitting $MODULES by comma and iterating over each module
         IFS=',' read -ra MODULES_ARRAY <<< "$MODULES"
         for MODULE in "${MODULES_ARRAY[@]}"; do
+            if [[ $MODULE == "text2vec-transformers-model2vec" ]]; then
+                helm_values="${helm_values} --set modules.text2vec-transformers.enabled=\"true\""
+                helm_values="${helm_values} --set modules.text2vec-transformers.repo=semitechnologies/model2vec-inference"
+                helm_values="${helm_values} --set modules.text2vec-transformers.tag=minishlab-potion-multilingual-128M"
+                continue
+            fi
             # Add module string to helm_values
             helm_values="${helm_values} --set modules.${MODULE}.enabled=\"true\""
             if [[ $MODULE == "text2vec-transformers" ]]; then
@@ -691,6 +700,16 @@ function use_local_images() {
                 "text2vec-contextionary")
                     WEAVIATE_IMAGES+=(
                         "semitechnologies/contextionary:en0.16.0-v1.2.1"
+                    )
+                    ;;
+                "text2vec-model2vec")
+                    WEAVIATE_IMAGES+=(
+                        "semitechnologies/model2vec-inference:minishlab-potion-retrieval-32M"
+                    )
+                    ;;
+                "text2vec-transformers-model2vec")
+                    WEAVIATE_IMAGES+=(
+                        "semitechnologies/model2vec-inference:minishlab-potion-multilingual-128M"
                     )
                     ;;
                 # Add more cases as needed for other modules


### PR DESCRIPTION
This PR adds two neew MODULES which level on the
model2vec models:
- text2vec-model2vec: which uses by default the model2vec-inference: minishlab-potion-retrieval-32M.
- text2vec-transformers-model2vec: This is the typical transformers module but using underneath a model2vec model, which is more performant and lowers the memory/cpu consumption. It relies on the image: model2vec-inference: minishlab-potion-multilingual-128M"