### PR TITLE
fix(raft): verify sync per node via exposed ports; avoid LB false pos…

### DIFF
--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -140,6 +140,7 @@ function upgrade() {
     # Check if Weaviate is up
     wait_for_all_healthy_nodes $REPLICAS
     # Check if Raft schema is in sync
+    # only if the cluster/statistics endpoint is available
     wait_for_raft_sync $REPLICAS
     echo_green "upgrade # Success"
 }
@@ -243,6 +244,9 @@ EOF
 
     # Check if Weaviate is up
     wait_for_all_healthy_nodes $REPLICAS
+    # Check if Raft schema is in sync
+    # only if the cluster/statistics endpoint is available
+    wait_for_raft_sync $REPLICAS
     echo_green "setup # Success"
     echo_green "setup # Weaviate is up and running on http://localhost:$WEAVIATE_PORT"
     if [[ $EXPOSE_PODS == "true" ]]; then


### PR DESCRIPTION
…itives

- Update wait_for_raft_sync in utilities/helpers.sh to query each node on localhost:(WEAVIATE_PORT + i + 1)/v1/cluster/statistics instead of the service port, preventing load balancer-induced false positives.
- Consider the cluster synchronized only when all nodes report synchronized == true and the expected statistics count.
- Add fallback to the service-port check when EXPOSE_PODS is not enabled.
- Improve logs to show per-node status and overall progress.