### PR TITLE
Make the porforwarding logic more robust

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,5 +175,5 @@ runs:
         echo "####### WEAVIATE STS CONFIG ######"
         kubectl get sts weaviate -n weaviate -o yaml || true
         echo "####### KUBECTL-RELAY PROCESSES ######"
-        pgrep kubectl-relay || echo "No kubectl-relay processes found" || true
+        ps aux | grep kubectl-relay || echo "No kubectl-relay processes found" || true
         

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -141,7 +141,7 @@ function upgrade() {
     wait_for_all_healthy_nodes $REPLICAS
     # Check if Raft schema is in sync
     # only if the cluster/statistics endpoint is available
-    wait_for_raft_sync $REPLICAS
+    wait_for_raft_sync $REPLICAS $TIMEOUT
     echo_green "upgrade # Success"
 }
 

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -418,14 +418,26 @@ function wait_for_raft_sync() {
         echo_green "Wait for Weaviate Raft schema to be in sync across $nodes_count nodes"
         while true; do
             synced_nodes=0
+            skipped_nodes=0
             for i in $(seq 0 $((nodes_count-1))); do
                 port=$((WEAVIATE_PORT+i+1))
+                # Skip if no kubectl-relay forward is present on this port (either port is busy or forward never started)
+                if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -q ":${port}"; then
+                    if lsof -i -n -P | grep LISTEN | grep -q ":${port}"; then
+                        echo_yellow "Skipping Node weaviate-$i Raft check: port ${port} in use by another process"
+                    else
+                        echo_yellow "Skipping Node weaviate-$i Raft check: no local forward on port ${port}"
+                    fi
+                    skipped_nodes=$((skipped_nodes+1))
+                    continue
+                fi
                 if is_statistics_synced_for_port "$port" "$nodes_count" "Node weaviate-$i"; then
                     synced_nodes=$((synced_nodes+1))
                 fi
             done
-            if [ "$synced_nodes" == "$nodes_count" ]; then
-                echo_green "Weaviate $synced_nodes nodes out of $nodes_count are synchronized."
+            expected_nodes=$((nodes_count - skipped_nodes))
+            if [ "$synced_nodes" == "$expected_nodes" ]; then
+                echo_green "Weaviate $synced_nodes nodes out of $expected_nodes are synchronized."
                 echo_green "Weaviate Raft cluster is in sync"
                 return
             fi
@@ -436,7 +448,7 @@ function wait_for_raft_sync() {
                 log_raft_sync_debug_info "$nodes_count"
                 exit 1
             fi
-            echo_yellow "Synchronized nodes: $synced_nodes/$nodes_count; retrying in 2s"
+            echo_yellow "Synchronized nodes: $synced_nodes/$expected_nodes; skipped: $skipped_nodes; retrying in 2s"
             sleep 2
         done
     else
@@ -531,9 +543,49 @@ function port_forward_weaviate_pods() {
         exit 1
     fi
 
+    # Reset skipped endpoints tracker for this invocation
+    FORWARD_SKIPPED_ENDPOINTS=""
+
+    # Helper: ensure kubectl-relay is listening on a local port for a given resource
+    function ensure_krelay_forward() {
+        local resource_type=$1     # svc|sts
+        local resource_name=$2     # resource name
+        local namespace=$3         # k8s namespace
+        local local_port=$4        # local listen port
+        local target_port=$5       # target port in cluster
+        local log_file=$6          # log file
+
+        # Already listening via kubectl-relay?
+        if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -q ":${local_port}"; then
+            return 0
+        fi
+
+        # If the port is used by something else, skip
+        if lsof -i -n -P | grep LISTEN | grep -q ":${local_port}"; then
+            echo_yellow "Port ${local_port} is in use by a non-relay process; skipping"
+            FORWARD_SKIPPED_ENDPOINTS="${FORWARD_SKIPPED_ENDPOINTS} ${resource_name}:${target_port}->${local_port}"
+            return 1
+        fi
+
+        /tmp/kubectl-relay ${resource_type}/${resource_name} -n ${namespace} ${local_port}:${target_port} &> ${log_file} &
+
+        # Wait briefly until port is listening, retrying a few times
+        for _ in {1..10}; do
+            if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -q ":${local_port}"; then
+                return 0
+            fi
+            sleep 0.5
+        done
+
+        echo_yellow "kubectl-relay failed to listen on ${local_port} for ${resource_type}/${resource_name}. Log (tail):"
+        tail -n 5 "${log_file}" 2>/dev/null || true
+        return 1
+    }
+
     # Create individual services for each pod
     for i in $(seq 0 $((REPLICAS-1))); do
-        kubectl apply -n weaviate -f - <<EOF
+        if ! kubectl get svc weaviate-$i -n weaviate &> /dev/null; then
+            kubectl apply -n weaviate -f - <<EOF
 apiVersion: v1
 kind: Service
 metadata:
@@ -555,22 +607,15 @@ spec:
     port: 6060
     targetPort: 6060
 EOF
+        fi
     done
 
     # Forward through services instead of direct pod references
     for i in $(seq 0 $((REPLICAS-1))); do
-        if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep ":$((WEAVIATE_PORT+i+1))"; then
-            /tmp/kubectl-relay svc/weaviate-$i -n weaviate $((WEAVIATE_PORT+i+1)):8080 &> /tmp/weaviate_frwd_$i.log &
-        fi
-        if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep ":$((WEAVIATE_GRPC_PORT+i+1))"; then
-            /tmp/kubectl-relay svc/weaviate-$i -n weaviate $((WEAVIATE_GRPC_PORT+i+1)):50051 &> /tmp/weaviate_grpc_frwd_$i.log &
-        fi
-        if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep ":$((WEAVIATE_METRICS+i+1))"; then
-            /tmp/kubectl-relay svc/weaviate-$i -n weaviate $((WEAVIATE_METRICS+i+1)):2112 &> /tmp/weaviate_metrics_frwd_$i.log &
-        fi
-        if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep ":$((PROFILER_PORT+i+1))"; then
-            /tmp/kubectl-relay svc/weaviate-$i -n weaviate $((PROFILER_PORT+i+1)):6060 &> /tmp/weaviate_profiler_frwd_$i.log &
-        fi
+        ensure_krelay_forward svc weaviate-$i weaviate $((WEAVIATE_PORT+i+1)) 8080 /tmp/weaviate_frwd_$i.log || true
+        ensure_krelay_forward svc weaviate-$i weaviate $((WEAVIATE_GRPC_PORT+i+1)) 50051 /tmp/weaviate_grpc_frwd_$i.log || true
+        ensure_krelay_forward svc weaviate-$i weaviate $((WEAVIATE_METRICS+i+1)) 2112 /tmp/weaviate_metrics_frwd_$i.log || true
+        ensure_krelay_forward svc weaviate-$i weaviate $((PROFILER_PORT+i+1)) 6060 /tmp/weaviate_profiler_frwd_$i.log || true
     done
 }
 


### PR DESCRIPTION
- Adds a timeout when checking for the RAFT cluster to be in sync.
- Keeps track of ports being already in use by other service at the time of forwarding some of the ports.
- If a port is in use, skips it from the RAFT in sync check.
- Improves the debugging information if the RAFT sync fails