### PR TITLE
Fix values-override YAML parsing for special characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,10 @@ jobs:
           env:
             ASYNC_INDEXING: true
             LOG_LEVEL: debug
+          runtime_overrides:
+            enabled: true
+            values:
+              objects_ttl_delete_schedule: "@every 10s"
         VALUES_INLINE: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=pread'
       steps:
         - name: Checkout repository
@@ -249,6 +253,12 @@ jobs:
               curl --fail -s -X POST -d grant_type=password -d client_id=demo -d username=admin -d password=admin http://keycloak.oidc.svc.cluster.local:9090/realms/weaviate/protocol/openid-connect/token | jq -r .access_token
               if [[ $? -ne 0 ]]; then
                   echo "Error: Failed to authenticate with the keycloak"
+                  exit 1
+              fi
+              # Verify runtime overrides ConfigMap was created with special character values (@ in cron schedule)
+              configmap_data=$(kubectl get configmap weaviate-runtime-overrides -n weaviate -o=jsonpath='{.data.overrides\.yaml}')
+              if ! echo "$configmap_data" | grep -q "@every 10s"; then
+                  echo "Error: runtime overrides ConfigMap does not contain '@every 10s'. Found: $configmap_data"
                   exit 1
               fi
     run-weaviate-local-k8s-which-fails:

--- a/action.yml
+++ b/action.yml
@@ -124,8 +124,10 @@ runs:
     - name: Create values-override.yaml
       shell: bash
       if: ${{ inputs.values-override != '' }}
+      env:
+        VALUES_CONTENT: ${{ inputs.values-override }}
       run: |
-        echo "${{ inputs.values-override }}" > ${{ github.action_path }}/values-override.yaml
+        printf '%s\n' "$VALUES_CONTENT" > ${{ github.action_path }}/values-override.yaml
     - name: Deploy local kubernetes cluster
       shell: bash
       env:


### PR DESCRIPTION
## Summary

- Fixes YAML parsing failure when `values-override` input contains special characters like `@` (e.g., `objects_ttl_delete_schedule: "@every 10s"`)
- Replaces inline `${{ }}` expression expansion with an environment variable + `printf` to preserve quoting

## Problem

The current approach:
```yaml
echo "${{ inputs.values-override }}" > values-override.yaml
```

GitHub Actions substitutes the expression **before** bash parses the command. When the YAML content contains double-quoted values with special characters like `"@every 10s"`, the inner quotes close the outer shell string, leaving the `@` unquoted in the resulting file. This causes Helm to fail with:

```
Error: failed to parse values-override.yaml: error converting YAML to JSON:
yaml: line 16: found character that cannot start any token
```

## Fix

Pass the content through an `env` variable and write it with `printf`:
```yaml
env:
  VALUES_CONTENT: ${{ inputs.values-override }}
run: |
  printf '%s\n' "$VALUES_CONTENT" > values-override.yaml
```

This avoids inline expression expansion entirely — bash receives the content as a properly-escaped shell variable, preserving all quotes and special characters verbatim.

## Test plan

- [ ] Deploy a cluster with `values-override` containing `@` characters (e.g., `objects_ttl_delete_schedule: "@every 10s"`)
- [ ] Verify the generated `values-override.yaml` has correct YAML syntax
- [ ] Verify Helm install succeeds without parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)