### PR TITLE
Document collection export in operating skill.

### DIFF
--- a/.claude/skills/operating-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/operating-weaviate-local-k8s/SKILL.md
@@ -44,6 +44,7 @@ Rule: `WORKERS >= REPLICAS - 1` (control-plane counts as a node).
 | OIDC auth | `OIDC=true RBAC=true` |
 | Dynamic users | `DYNAMIC_USERS=true RBAC=true` |
 | S3 backups | `ENABLE_BACKUP=true` |
+| Collection export | `ENABLE_BACKUP=true` |
 | Tenant offloading | `S3_OFFLOAD=true` |
 | Usage metrics | `USAGE_S3=true ENABLE_RUNTIME_OVERRIDES=true` |
 | Modules | `MODULES="text2vec-transformers"` |
@@ -113,6 +114,8 @@ WEAVIATE_VERSION="1.28.0" ENABLE_BACKUP=true ./local-k8s.sh setup
 ```
 
 MinIO on port 9000. Credentials: `aws_access_key` / `aws_secret_key`.
+
+**Note**: `ENABLE_BACKUP=true` also enables collection export (`weaviate-cli create export-collection`). Export uses the same S3 storage backend (MinIO) as backups.
 
 When both `ENABLE_BACKUP=true` and `USAGE_S3=true` are enabled, MinIO serves both purposes with separate buckets:
 - `weaviate-backups/` — backup data

--- a/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
@@ -117,6 +117,22 @@ HELM_TIMEOUT="20m" ./local-k8s.sh setup
 
 Module images are large. Timeout automatically increases by 1200s.
 
+### Collection Export Testing
+
+```bash
+WORKERS=2 REPLICAS=3 WEAVIATE_VERSION="1.37.0" \
+ENABLE_BACKUP=true \
+./local-k8s.sh setup
+```
+
+Collection export requires `ENABLE_BACKUP=true` (uses the same MinIO S3 backend as backups). Test with `weaviate-cli`:
+
+```bash
+weaviate-cli create export-collection --export_id my-export --backend s3 --wait --json
+weaviate-cli get export-collection --export_id my-export --backend s3 --json
+weaviate-cli cancel export-collection --export_id my-export --backend s3 --json
+```
+
 ### CI/CD Pipeline
 
 ```bash

--- a/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
@@ -59,7 +59,7 @@ All are string `"true"` / `"false"`.
 |----------|---------|-------------|--------------|
 | `OBSERVABILITY` | `"true"` | Prometheus + Grafana stack | |
 | `EXPOSE_PODS` | `"true"` | Per-pod port forwarding | |
-| `ENABLE_BACKUP` | `"false"` | S3 backup via MinIO | Deploys MinIO |
+| `ENABLE_BACKUP` | `"false"` | S3 backup and collection export via MinIO | Deploys MinIO |
 | `S3_OFFLOAD` | `"false"` | Tenant offloading to S3 | Deploys MinIO |
 | `USAGE_S3` | `"false"` | Usage metrics in S3 | Requires `ENABLE_RUNTIME_OVERRIDES=true` |
 | `ENABLE_RUNTIME_OVERRIDES` | `"false"` | Dynamic config reloading (30s interval) | |


### PR DESCRIPTION
Add collection export to feature selection table, deployment patterns, and environment variable descriptions. Export requires ENABLE_BACKUP=true which provides the S3 storage backend via MinIO.