### PR TITLE
Remove separate MCP port, use REST endpoint /v1/mcp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,6 @@ jobs:
         WEAVIATE_PORT: '8081'
         WEAVIATE_GRPC_PORT: '50052'
         MCP_ENABLED: 'true'
-        MCP_PORT_FORWARDED: '9901'
         HELM_BRANCH: 'main'
         S3_OFFLOAD: 'true'
         MODULES: 'text2vec-model2vec'
@@ -258,9 +257,9 @@ jobs:
                   echo "Error: Failed to authenticate with the keycloak"
                   exit 1
               fi
-              error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{ env.MCP_PORT_FORWARDED }}/health)
+              error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{ env.WEAVIATE_PORT }}/v1/mcp)
               if [[ "$error" -ne 200 ]]; then
-                echo "Error: MCP service is not listening, returned $error"
+                echo "Error: MCP server is not listening, returned $error"
                 exit 1
               # Verify runtime overrides ConfigMap was created with special character values (@ in cron schedule)
               configmap_data=$(kubectl get configmap weaviate-runtime-overrides -n weaviate -o=jsonpath='{.data.overrides\.yaml}')

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -67,7 +67,6 @@ DYNAMIC_USERS=${DYNAMIC_USERS:-"false"}
 AUTH_CONFIG=${AUTH_CONFIG:-""}
 DEBUG=${DEBUG:-"false"}
 MCP_ENABLED=${MCP_ENABLED:-"false"}
-MCP_PORT_FORWARDED=${MCP_PORT_FORWARDED:-"9900"}
 DOCKER_CONFIG=${DOCKER_CONFIG:-""}
 ENABLE_RUNTIME_OVERRIDES=${ENABLE_RUNTIME_OVERRIDES:-"false"}
 RUNTIME_OVERRIDES_PATH=${RUNTIME_OVERRIDES_PATH:-"/config/overrides.yaml"}
@@ -325,7 +324,7 @@ EOF
         echo_green "setup # Dash0 monitoring is enabled and configured"
     fi
     if [[ $MCP_ENABLED == "true" ]]; then
-        echo_green "setup # MCP service is enabled and accessible on http://localhost:$MCP_PORT_FORWARDED/mcp"
+        echo_green "setup # MCP server is enabled and accessible on http://localhost:$WEAVIATE_PORT/v1/mcp"
     fi
 }
 

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -630,9 +630,6 @@ function port_forward_to_weaviate() {
     if [[ $USAGE_S3 == "true" ]]; then
        /tmp/kubectl-relay svc/minio -n weaviate ${MINIO_PORT}:9000 &> /tmp/minio_frwd.log &
     fi
-    if [[ $MCP_ENABLED == "true" ]]; then
-        /tmp/kubectl-relay svc/weaviate-mcp -n weaviate ${MCP_PORT_FORWARDED}:9000 &> /tmp/mcp_frwd.log &
-    fi
 }
 
 function port_forward_weaviate_pods() {


### PR DESCRIPTION
## Summary

- Aligns with [weaviate/weaviate#10847](https://github.com/weaviate/weaviate/pull/10847) and [weaviate/weaviate-helm#324](https://github.com/weaviate/weaviate-helm/pull/324) which move MCP from a dedicated port (9000) to the main REST API at `/v1/mcp`
- Removes `MCP_PORT_FORWARDED` variable and the separate `weaviate-mcp` service port forwarding — MCP is now accessible through the existing Weaviate REST port forward
- Updates CI health check to hit `localhost:<WEAVIATE_PORT>/v1/mcp` instead of the old separate port

## Dependencies

- weaviate/weaviate-helm#324