### PR TITLE
Add COLLECTION_EXPORT support via collectionExport Helm feature

### DIFF
--- a/.claude/skills/operating-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/operating-weaviate-local-k8s/SKILL.md
@@ -44,7 +44,7 @@ Rule: `WORKERS >= REPLICAS - 1` (control-plane counts as a node).
 | OIDC auth | `OIDC=true RBAC=true` |
 | Dynamic users | `DYNAMIC_USERS=true RBAC=true` |
 | S3 backups | `ENABLE_BACKUP=true` |
-| Collection export | `ENABLE_BACKUP=true` |
+| Collection export | `COLLECTION_EXPORT=true` |
 | Tenant offloading | `S3_OFFLOAD=true` |
 | Usage metrics | `USAGE_S3=true ENABLE_RUNTIME_OVERRIDES=true` |
 | Modules | `MODULES="text2vec-transformers"` |
@@ -117,7 +117,7 @@ WEAVIATE_VERSION="1.28.0" ENABLE_BACKUP=true ./local-k8s.sh setup
 
 MinIO on port 9000. Credentials: `aws_access_key` / `aws_secret_key`.
 
-**Note**: `ENABLE_BACKUP=true` also enables collection export (`weaviate-cli create export-collection`). Export uses the same S3 storage backend (MinIO) as backups.
+Collection export is configured separately via `COLLECTION_EXPORT=true` (see the Collection Export section below). Both backup and collection export use MinIO as the S3 backend.
 
 When both `ENABLE_BACKUP=true` and `USAGE_S3=true` are enabled, MinIO serves both purposes with separate buckets:
 - `weaviate-backups/` — backup data
@@ -125,12 +125,30 @@ When both `ENABLE_BACKUP=true` and `USAGE_S3=true` are enabled, MinIO serves bot
 
 Browse usage data: `kubectl exec -n weaviate minio -- mc alias set local http://localhost:9000 aws_access_key aws_secret_key && kubectl exec -n weaviate minio -- mc ls --recursive local/weaviate-usage/`
 
+### With Collection Export (MinIO S3)
+
+```bash
+WEAVIATE_VERSION="1.28.0" COLLECTION_EXPORT=true ./local-k8s.sh setup
+```
+
+Enables the `collectionExport` Helm feature, which sets `EXPORT_ENABLED=true` and `EXPORT_DEFAULT_BUCKET=weaviate-export` in Weaviate. Creates the `weaviate-export` bucket in MinIO automatically.
+
+Collection export uses the backup-s3 module as its S3 storage backend. If `ENABLE_BACKUP=true` is not also set, the backup-s3 module is automatically configured to point to MinIO so collection export can function. Test with:
+
+```bash
+weaviate-cli create export-collection --export_id my-export --backend s3 --wait --json
+weaviate-cli get export-collection --export_id my-export --backend s3 --json
+weaviate-cli cancel export-collection --export_id my-export --backend s3 --json
+```
+
+MinIO buckets used: `weaviate-export/` (export data), `weaviate-backups/` (backup data if `ENABLE_BACKUP=true`).
+
 ### Full-Featured
 
 ```bash
 WORKERS=2 REPLICAS=3 WEAVIATE_VERSION="1.28.0" \
   MODULES="text2vec-transformers,generative-openai" \
-  RBAC=true ENABLE_BACKUP=true S3_OFFLOAD=true \
+  RBAC=true ENABLE_BACKUP=true COLLECTION_EXPORT=true S3_OFFLOAD=true \
   ENABLE_RUNTIME_OVERRIDES=true OBSERVABILITY=true \
   HELM_TIMEOUT="20m" ./local-k8s.sh setup
 ```

--- a/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
@@ -121,11 +121,13 @@ Module images are large. Timeout automatically increases by 1200s.
 
 ```bash
 WORKERS=2 REPLICAS=3 WEAVIATE_VERSION="1.37.0" \
-ENABLE_BACKUP=true \
+COLLECTION_EXPORT=true \
 ./local-k8s.sh setup
 ```
 
-Collection export requires `ENABLE_BACKUP=true` (uses the same MinIO S3 backend as backups). Test with `weaviate-cli`:
+`COLLECTION_EXPORT=true` enables the `collectionExport` Helm feature (`collectionExport.enabled=true`, `EXPORT_DEFAULT_BUCKET=weaviate-export`). MinIO is started automatically and the `weaviate-export` bucket is created.
+
+Collection export uses the backup-s3 module as its S3 backend. If `ENABLE_BACKUP=true` is not also set, the backup-s3 module is automatically configured to point to MinIO (no user action needed). Test with `weaviate-cli`:
 
 ```bash
 weaviate-cli create export-collection --export_id my-export --backend s3 --wait --json

--- a/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
@@ -59,7 +59,8 @@ All are string `"true"` / `"false"`.
 |----------|---------|-------------|--------------|
 | `OBSERVABILITY` | `"true"` | Prometheus + Grafana stack | |
 | `EXPOSE_PODS` | `"true"` | Per-pod port forwarding | |
-| `ENABLE_BACKUP` | `"false"` | S3 backup and collection export via MinIO | Deploys MinIO |
+| `ENABLE_BACKUP` | `"false"` | S3 backup via MinIO | Deploys MinIO |
+| `COLLECTION_EXPORT` | `"false"` | Collection export to S3/MinIO (`collectionExport` Helm feature) | Deploys MinIO; auto-configures backup-s3 module if `ENABLE_BACKUP=false` |
 | `S3_OFFLOAD` | `"false"` | Tenant offloading to S3 | Deploys MinIO |
 | `USAGE_S3` | `"false"` | Usage metrics in S3 | Requires `ENABLE_RUNTIME_OVERRIDES=true` |
 | `ENABLE_RUNTIME_OVERRIDES` | `"false"` | Dynamic config reloading (30s interval) | |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
         S3_OFFLOAD: 'true'
         MODULES: 'text2vec-model2vec'
         ENABLE_BACKUP: 'true'
+        COLLECTION_EXPORT: 'true'
         USAGE_S3: 'true'
         ENABLE_RUNTIME_OVERRIDES: 'true'
         RBAC: 'true'
@@ -168,6 +169,7 @@ jobs:
             enable-runtime-overrides: ${{ env.ENABLE_RUNTIME_OVERRIDES }}
             modules: ${{ env.MODULES }}
             enable-backup: ${{ env.ENABLE_BACKUP }}
+            collection-export: ${{ env.COLLECTION_EXPORT }}
             values-inline: ${{ env.VALUES_INLINE }}
             observability: 'true'
             rbac: ${{ env.RBAC }}
@@ -530,6 +532,8 @@ jobs:
         WORKERS: '1'
         REPLICAS: '5'
         WEAVIATE_VERSION: '1.26.3'
+        ENABLE_BACKUP: 'true'
+        COLLECTION_EXPORT: 'true'
       steps:
         - name: Checkout repository
           uses: actions/checkout@v2
@@ -539,7 +543,8 @@ jobs:
           with:
             workers: ${{ env.WORKERS }}
             replicas: ${{ env.REPLICAS }}
-            enable-backup: 'true'
+            enable-backup: ${{ env.ENABLE_BACKUP }}
+            collection-export: ${{ env.COLLECTION_EXPORT }}
             weaviate-version: ${{ env.WEAVIATE_VERSION }}
         - name: Check the configured values
           run: |
@@ -584,6 +589,21 @@ jobs:
               echo "The backup has been started."
             else
               echo "The backup status is not STARTED/SUCCEEDED or the json output is not the expected."
+              exit 1
+            fi
+            echo "Create a collection export"
+            curl -X POST -H "Content-Type: application/json" \
+              -d '{
+                  "id": "test-collection-export",
+                  "include": ["Article"],
+                  "fileFormat": "parquet"
+                  }' \
+              http://localhost:8080/v1/export/s3
+            response=$(curl -s http://localhost:8080/v1/export/s3/test-collection-export)
+            if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCEEDED" or .status == "RUNNING"' > /dev/null 2>&1; then
+              echo "The collection export has been started."
+            else
+              echo "The collection export status is not STARTED/RUNNING/SUCCEEDED or the json output is not the expected."
               exit 1
             fi
     run-weaviate-local-k8s-rbac:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,20 +282,25 @@ jobs:
                 -H "Authorization: Bearer admin-key" \
                 -d '{"class": "ExportTest"}' \
                 http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/schema
+              echo "Insert an object so the export has data"
+              curl -X POST -H "Content-Type: application/json" \
+                -H "Authorization: Bearer admin-key" \
+                -d '{"class": "ExportTest", "properties": {}}' \
+                http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/objects
               echo "Create a collection export"
               curl -X POST -H "Content-Type: application/json" \
                 -H "Authorization: Bearer admin-key" \
                 -d '{
                     "id": "test-collection-export",
                     "include": ["ExportTest"],
-                    "fileFormat": "parquet"
+                    "file_format": "parquet"
                     }' \
                 http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/export/s3
               response=$(curl -s -H "Authorization: Bearer admin-key" http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/export/s3/test-collection-export)
-              if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCEEDED" or .status == "RUNNING"' > /dev/null 2>&1; then
+              if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCESS" or .status == "RUNNING"' > /dev/null 2>&1; then
                 echo "The collection export has been started."
               else
-                echo "The collection export status is not STARTED/RUNNING/SUCCEEDED or the json output is not the expected."
+                echo "The collection export status is not STARTED/RUNNING/SUCCESS or the json output is not the expected."
                 exit 1
               fi
     run-weaviate-local-k8s-which-fails:
@@ -547,12 +552,13 @@ jobs:
               exit 1
             fi
     run-weaviate-local-k8s-backup:
+      needs: get-latest-weaviate-version
       runs-on: ubuntu-latest
       name: Invoke weaviate-local-k8s action with support for backup
       env:
         WORKERS: '1'
         REPLICAS: '5'
-        WEAVIATE_VERSION: '1.26.3'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
         ENABLE_BACKUP: 'true'
         COLLECTION_EXPORT: 'true'
       steps:
@@ -599,6 +605,10 @@ jobs:
                   "class": "Article"
                   }' \
               http://localhost:8080/v1/schema
+            echo "Insert an object so backup and export have data"
+            curl -X POST -H "Content-Type: application/json" \
+              -d '{"class": "Article", "properties": {}}' \
+              http://localhost:8080/v1/objects
             echo "Create a backup"
             curl -X POST -H "Content-Type: application/json" \
               -d '{
@@ -617,14 +627,14 @@ jobs:
               -d '{
                   "id": "test-collection-export",
                   "include": ["Article"],
-                  "fileFormat": "parquet"
+                  "file_format": "parquet"
                   }' \
               http://localhost:8080/v1/export/s3
             response=$(curl -s http://localhost:8080/v1/export/s3/test-collection-export)
-            if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCEEDED" or .status == "RUNNING"' > /dev/null 2>&1; then
+            if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCESS" or .status == "RUNNING"' > /dev/null 2>&1; then
               echo "The collection export has been started."
             else
-              echo "The collection export status is not STARTED/RUNNING/SUCCEEDED or the json output is not the expected."
+              echo "The collection export status is not STARTED/RUNNING/SUCCESS or the json output is not the expected."
               exit 1
             fi
     run-weaviate-local-k8s-rbac:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,6 +277,27 @@ jobs:
                   echo "Error: runtime overrides ConfigMap does not contain '@every 10s'. Found: $configmap_data"
                   exit 1
               fi
+              echo "Create a collection for export"
+              curl -X POST -H "Content-Type: application/json" \
+                -H "Authorization: Bearer admin-key" \
+                -d '{"class": "ExportTest"}' \
+                http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/schema
+              echo "Create a collection export"
+              curl -X POST -H "Content-Type: application/json" \
+                -H "Authorization: Bearer admin-key" \
+                -d '{
+                    "id": "test-collection-export",
+                    "include": ["ExportTest"],
+                    "fileFormat": "parquet"
+                    }' \
+                http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/export/s3
+              response=$(curl -s -H "Authorization: Bearer admin-key" http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/export/s3/test-collection-export)
+              if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCEEDED" or .status == "RUNNING"' > /dev/null 2>&1; then
+                echo "The collection export has been started."
+              else
+                echo "The collection export status is not STARTED/RUNNING/SUCCEEDED or the json output is not the expected."
+                exit 1
+              fi
     run-weaviate-local-k8s-which-fails:
       runs-on: ubuntu-latest
       name: Create a single-node Weaviate cluster with non existing image.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,17 +278,17 @@ jobs:
                   exit 1
               fi
               echo "Create a collection for export"
-              curl -X POST -H "Content-Type: application/json" \
+              curl --fail-with-body -X POST -H "Content-Type: application/json" \
                 -H "Authorization: Bearer admin-key" \
                 -d '{"class": "ExportTest"}' \
                 http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/schema
               echo "Insert an object so the export has data"
-              curl -X POST -H "Content-Type: application/json" \
+              curl --fail-with-body -X POST -H "Content-Type: application/json" \
                 -H "Authorization: Bearer admin-key" \
                 -d '{"class": "ExportTest", "properties": {}}' \
                 http://127.0.0.1:${{ env.WEAVIATE_PORT }}/v1/objects
               echo "Create a collection export"
-              curl -X POST -H "Content-Type: application/json" \
+              curl --fail-with-body -X POST -H "Content-Type: application/json" \
                 -H "Authorization: Bearer admin-key" \
                 -d '{
                     "id": "test-collection-export",
@@ -600,17 +600,17 @@ jobs:
               exit 1
             fi
             echo "Create a collection"
-            curl -X POST -H "Content-Type: application/json" \
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
               -d '{
                   "class": "Article"
                   }' \
               http://localhost:8080/v1/schema
             echo "Insert an object so backup and export have data"
-            curl -X POST -H "Content-Type: application/json" \
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
               -d '{"class": "Article", "properties": {}}' \
               http://localhost:8080/v1/objects
             echo "Create a backup"
-            curl -X POST -H "Content-Type: application/json" \
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
               -d '{
                   "id": "test-backup"
                   }' \
@@ -623,7 +623,7 @@ jobs:
               exit 1
             fi
             echo "Create a collection export"
-            curl -X POST -H "Content-Type: application/json" \
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
               -d '{
                   "id": "test-collection-export",
                   "include": ["Article"],

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Configures S3 compatible backup for Weaviate'
     required: false
     default: 'false'
+  collection-export:
+    description: 'Enables collection export to S3/MinIO via the collectionExport Helm feature'
+    required: false
+    default: 'false'
   s3-offload:
     description: 'Configures S3 tenant offloading'
     required: false
@@ -149,6 +153,7 @@ runs:
         MODULES: ${{ inputs.modules }}
         HELM_BRANCH: ${{ inputs.helm-branch }}
         ENABLE_BACKUP: ${{ inputs.enable-backup }}
+        COLLECTION_EXPORT: ${{ inputs.collection-export }}
         S3_OFFLOAD: ${{ inputs.s3-offload }}
         USAGE_S3 : ${{ inputs.usage-s3 }}
         DELETE_STS: ${{ inputs.delete-sts }}

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -42,6 +42,7 @@ EXPOSE_PODS=${EXPOSE_PODS:-"true"}
 WEAVIATE_IMAGE_PREFIX=${WEAVIATE_IMAGE_PREFIX:-semitechnologies}
 MODULES=${MODULES:-""}
 ENABLE_BACKUP=${ENABLE_BACKUP:-"false"}
+COLLECTION_EXPORT=${COLLECTION_EXPORT:-"false"}
 S3_OFFLOAD=${S3_OFFLOAD:-"false"}
 USAGE_S3=${USAGE_S3:-"false"}
 HELM_BRANCH=${HELM_BRANCH:-""}
@@ -76,7 +77,7 @@ if [[ $DEBUG == "true" ]]; then
     set -x
 fi
 
-if [[ "$ENABLE_BACKUP" == "true" ]] || [[ "$S3_OFFLOAD" == "true" ]] || [[ "$USAGE_S3" == "true" ]]; then
+if [[ "$ENABLE_BACKUP" == "true" ]] || [[ "$S3_OFFLOAD" == "true" ]] || [[ "$USAGE_S3" == "true" ]] || [[ "$COLLECTION_EXPORT" == "true" ]]; then
     need_minio="true"
 else
     need_minio="false"

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -124,6 +124,10 @@ Environment Variables:
     S3_OFFLOAD                  Enable S3 data offloading with MinIO (default: false)
     USAGE_S3                    Enable collecting usage metrics in MinIO (default: false)
     ENABLE_RUNTIME_OVERRIDES    Enable weaviate configuration via runtime overrides(default: false)
+    MCP_ENABLED                 Enable MCP server (default: false)
+    MCP_WRITE_ACCESS            Enable MCP write access (default: false)
+    COLLECTION_EXPORT           Enable collection export to S3/MinIO (default: false)
+    RUNTIME_OVERRIDES_PATH      Path to runtime overrides configuration file (default: "/config/overrides.yaml")
 
   Dash0 Configuration (when DASH0=true):
     CLUSTER_NAME                Cluster identifier for Dash0 (default: "weaviate-local-cluster")

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -186,7 +186,7 @@ EOF
 function wait_for_minio() {
     kubectl wait pod/minio -n weaviate --for=condition=Ready --timeout=300s
     echo_green "Minio is ready"
-    if [[ $ENABLE_BACKUP == "true" || $USAGE_S3 == "true" ]]; then
+    if [[ $ENABLE_BACKUP == "true" || $USAGE_S3 == "true" || $COLLECTION_EXPORT == "true" ]]; then
         # Run minio/mc in a single shot to create the bucket
         # Check if the minio-mc pod already exists and delete it if necessary
         if kubectl get pod minio-mc -n weaviate &>/dev/null; then
@@ -199,13 +199,19 @@ function wait_for_minio() {
                 /usr/bin/mc mb minio/weaviate-backups;
                 /usr/bin/mc policy set public minio/weaviate-backups;
             else
-                echo 'Bucket minio/weaviate-usage already exists.';
+                echo 'Bucket minio/weaviate-backups already exists.';
             fi;
             if ! /usr/bin/mc ls minio/weaviate-usage > /dev/null 2>&1; then
                 /usr/bin/mc mb minio/weaviate-usage;
                 /usr/bin/mc policy set public minio/weaviate-usage;
             else
                 echo 'Bucket minio/weaviate-usage already exists.';
+            fi;
+            if ! /usr/bin/mc ls minio/weaviate-export > /dev/null 2>&1; then
+                /usr/bin/mc mb minio/weaviate-export;
+                /usr/bin/mc policy set public minio/weaviate-export;
+            else
+                echo 'Bucket minio/weaviate-export already exists.';
             fi;"
             # Wait for the pod/minio-mc to complete
             timeout=100  # Timeout in seconds
@@ -789,6 +795,24 @@ TZEOF
             secrets=""
         fi
         helm_values="${helm_values} --set offload.s3.enabled=true --set offload.s3.envconfig.OFFLOAD_S3_BUCKET_AUTO_CREATE=true --set offload.s3.envconfig.OFFLOAD_S3_ENDPOINT=http://minio:9000 ${secrets}"
+    fi
+
+    if [[ $COLLECTION_EXPORT == "true" ]]; then
+        helm_values="${helm_values} --set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_BUCKET=weaviate-export"
+        if [[ $ENABLE_BACKUP != "true" ]]; then
+            # Collection export uses the backup-s3 module as its S3 storage backend. When backup
+            # is not already enabled, configure the backup-s3 module to point to MinIO so that
+            # collection export can write to it.
+            # Avoid setting backups.s3.secrets when offload is also active: the weaviate-helm
+            # awsSecret.yaml guard fails if more than one feature provides AWS credential secrets.
+            # When offload is active, its credentials are already in the container and the
+            # backup-s3 module will pick them up without needing its own secret.
+            backup_s3_secrets=""
+            if [[ $S3_OFFLOAD != "true" ]]; then
+                backup_s3_secrets="--set backups.s3.secrets.AWS_ACCESS_KEY_ID=aws_access_key --set backups.s3.secrets.AWS_SECRET_ACCESS_KEY=aws_secret_key"
+            fi
+            helm_values="${helm_values} --set backups.s3.enabled=true --set backups.s3.envconfig.BACKUP_S3_ENDPOINT=minio:9000 --set backups.s3.envconfig.BACKUP_S3_USE_SSL=false ${backup_s3_secrets}"
+        fi
     fi
 
     if [[ $ENABLE_RUNTIME_OVERRIDES == "true" ]]; then


### PR DESCRIPTION
## Summary

- Introduces `COLLECTION_EXPORT` env var (default `false`) backed by the new `collectionExport` Helm values from [weaviate/weaviate-helm#325](https://github.com/weaviate/weaviate-helm/pull/325)
- When `COLLECTION_EXPORT=true`: MinIO starts, `weaviate-export` bucket is created, `collectionExport.enabled=true` and `EXPORT_DEFAULT_BUCKET=weaviate-export` are passed to Helm
- Collection export uses the backup-s3 module as its S3 backend; if `ENABLE_BACKUP` is not set, backup-s3 is automatically configured to point to MinIO (credentials are skipped when `S3_OFFLOAD` is active to avoid the weaviate-helm multi-source credential guard)
- Adds `collection-export` input to `action.yml`
- CI `run-weaviate-local-k8s-all-params` job now enables `COLLECTION_EXPORT=true` and verifies a collection export can be created via `POST /v1/export/s3`
- Updates `operating-weaviate-local-k8s` skill with `COLLECTION_EXPORT=true` usage, a dedicated deployment pattern section, and env-var table entry

## Test plan

- [x] Deploy with `COLLECTION_EXPORT=true` only: verify MinIO starts, `weaviate-export` bucket exists, `EXPORT_ENABLED=true` env var is set in the Weaviate pod
- [x] Deploy with `COLLECTION_EXPORT=true ENABLE_BACKUP=true`: verify both features work, no duplicate env var errors
- [ ] Deploy with `COLLECTION_EXPORT=true S3_OFFLOAD=true`: verify no `awsSecret.yaml` multi-source guard failure
- [x] CI `run-weaviate-local-k8s-all-params` passes with the new collection export test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)