### PR TITLE
Pass renderer_token to avoid Grafana crashing.

### DIFF
--- a/helm/kube-prometheus-stack.yaml
+++ b/helm/kube-prometheus-stack.yaml
@@ -8,6 +8,7 @@ grafana:
     rendering:
       server_url: http://grafana-renderer.monitoring.svc.cluster.local:8081/render
       callback_url: http://prometheus-grafana.monitoring.svc.cluster.local/
+      renderer_token: weaviate-local-k8s
 
 prometheus:
   enabled: true

--- a/manifests/grafana-renderer.yaml
+++ b/manifests/grafana-renderer.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
         - name: grafana-renderer
           image: grafana/grafana-image-renderer:latest
+          env:
+            - name: AUTH_TOKEN
+              value: "weaviate-local-k8s"
           ports:
             - containerPort: 8081
           resources:


### PR DESCRIPTION
 Grafana 13.0.1 (released 2026-04-17) now refuses to
 start if renderer_token is left at its default value —
it's treated as a security violation in production mode. Passing a default token weaviate-local-k8s.