### PR TITLE
Fix port-availability check matching ports as substrings

### DIFF
--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
@@ -18,6 +18,7 @@ Test coverage map, adding tests, and quality standards.
 | Expose pods | `run-weaviate-local-k8s-expose-pods` | Per-pod port forwarding, pod restart reconnection |
 | OIDC | `run-weaviate-local-k8s-oidc` | Keycloak OIDC, user creation, token auth |
 | Port in use | `run-weaviate-local-k8s-port-in-use` | Port availability check fails when port occupied |
+| Substring port | `run-weaviate-local-k8s-substring-port` | Superset ports (e.g. 21146 vs 2114, 60616 vs 6061) do not block the pre-check or skip forwarding. Exact-port blocking is covered by `run-weaviate-local-k8s-port-in-use` |
 
 ## Standard Verification Checks
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -955,4 +955,106 @@ jobs:
           run: |
             echo "The deployment should have failed due to port 8080 being in use, but it succeeded"
             exit 1
+    run-weaviate-local-k8s-substring-port:
+      needs: get-latest-weaviate-version
+      runs-on: ubuntu-latest
+      name: Verify substring-superset ports do not block setup or forwarding
+      env:
+        WORKERS: '1'
+        REPLICAS: '2'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+        EXPOSE_PODS: 'true'
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Occupy ports that contain Weaviate ports as substrings
+          run: |
+            # A buggy unanchored match (grep ":2114") treats a Weaviate port as
+            # taken whenever a listener's port string starts with it, e.g. :21146
+            # begins with :2114. Occupy several such superset ports. Only the
+            # metrics (211xx) and profiler (606xx) families are collidable: an
+            # HTTP (8080x) or gRPC (50051x) superset would exceed the 65535 max.
+            #   21146 -> 2114 (weaviate-1 metrics: per-pod loop check + forward)
+            #   60616 -> 6061 (weaviate-0 profiler: per-pod loop check + forward)
+            #   21126 -> 2112 (default metrics: pre-flight default-port check)
+            # That an exact listener *does* block setup is covered separately by
+            # run-weaviate-local-k8s-port-in-use.
+            PIDS=""
+            for p in 21146 60616 21126; do
+              python3 -m http.server "$p" --bind 127.0.0.1 &
+              PIDS="$PIDS $!"
+            done
+            sleep 2
+            for p in 21146 60616 21126; do
+              if ! lsof -i :"$p" | grep -q LISTEN; then
+                echo "Failed to occupy port $p"
+                exit 1
+              fi
+            done
+            echo "SQUAT_PIDS=$PIDS" >> $GITHUB_ENV
+        - name: Deploy weaviate-local-k8s (must succeed despite the listeners)
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            expose-pods: ${{ env.EXPOSE_PODS }}
+        - name: Verify the cluster came up and substring ports were forwarded
+          run: |
+            set -ex
+            # Setup succeeding at all proves the pre-flight check did not falsely
+            # flag 2112/2114/6061 because of the :21126/:21146/:60616 listeners.
+            for retry in {1..30}; do
+              if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/v1/nodes | grep -q 200; then
+                break
+              fi
+              echo "Weaviate not ready, retry $retry/30"
+              sleep 2
+              if [[ $retry -eq 30 ]]; then
+                echo "ERROR: cluster did not come up"
+                exit 1
+              fi
+            done
+            NODE_COUNT=$(curl -s http://127.0.0.1:8080/v1/nodes | jq '.nodes | length')
+            if [[ "$NODE_COUNT" -ne 2 ]]; then
+              echo "ERROR: expected 2 nodes, found $NODE_COUNT"
+              exit 1
+            fi
+
+            # weaviate-1 metrics (:2114) must be forwarded, not skipped due to
+            # the :21146 listener.
+            for retry in {1..30}; do
+              if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:2114/metrics | grep -q 200; then
+                echo "Metrics port 2114 is forwarded and reachable"
+                break
+              fi
+              echo "Metrics port 2114 not ready, retry $retry/30"
+              sleep 2
+              if [[ $retry -eq 30 ]]; then
+                echo "ERROR: Metrics port 2114 not forwarded (substring match regression?)"
+                lsof -i -n -P | grep LISTEN | grep kubectl-r || true
+                exit 1
+              fi
+            done
+            # The listener on :2114 must be kubectl-relay, not a squatter.
+            if ! lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -qE ":2114([^0-9]|$)"; then
+              echo "ERROR: No kubectl-relay listener on exactly :2114"
+              lsof -i -n -P | grep LISTEN | grep kubectl-r || true
+              exit 1
+            fi
+
+            # weaviate-0 profiler (:6061) must be forwarded, not skipped due to
+            # the :60616 listener.
+            if ! nc -z -w 5 127.0.0.1 6061; then
+              echo "ERROR: profiler port 6061 not forwarded"
+              lsof -i -n -P | grep LISTEN | grep kubectl-r || true
+              exit 1
+            fi
+        - name: Stop the port-occupying servers
+          if: always()
+          run: |
+            for pid in ${SQUAT_PIDS:-}; do
+              kill "$pid" || true
+            done
 

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -670,12 +670,12 @@ function port_forward_weaviate_pods() {
         local log_file=$6          # log file
 
         # Already listening via kubectl-relay?
-        if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -q ":${local_port}"; then
+        if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -qE ":${local_port}([^0-9]|$)"; then
             return 0
         fi
 
         # If the port is used by something else, skip
-        if lsof -i -n -P | grep LISTEN | grep -q ":${local_port}"; then
+        if is_port_in_use "$local_port"; then
             echo_yellow "Port ${local_port} is in use by a non-relay process; skipping"
             FORWARD_SKIPPED_ENDPOINTS="${FORWARD_SKIPPED_ENDPOINTS} ${resource_name}:${target_port}->${local_port}"
             return 1
@@ -685,7 +685,7 @@ function port_forward_weaviate_pods() {
 
         # Wait briefly until port is listening, retrying a few times
         for _ in {1..10}; do
-            if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -q ":${local_port}"; then
+            if lsof -i -n -P | grep LISTEN | grep kubectl-r | grep -qE ":${local_port}([^0-9]|$)"; then
                 return 0
             fi
             sleep 0.5

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -360,24 +360,32 @@ function is_node_healthy() {
     fi
 }
 
+# Returns 0 if a process is LISTENing on the exact TCP port, 1 otherwise.
+# The port is matched followed by a non-digit (or end of line) so that, e.g.,
+# checking 2114 does not falsely match a listener on 21146.
+function is_port_in_use() {
+    local port=$1
+    lsof -i -n -P | grep LISTEN | grep -qE ":${port}([^0-9]|\$)"
+}
+
 function verify_ports_available() {
     replicas=$1
     echo_green "Verifying ports are available for $replicas Weaviate nodes"
 
     # Check if default ports are available
-    if lsof -i -n -P | grep LISTEN | grep -q ":$WEAVIATE_PORT"; then
+    if is_port_in_use "$WEAVIATE_PORT"; then
         echo_red "Port $WEAVIATE_PORT is already in use by another process."
         exit 1
     fi
-    if lsof -i -n -P | grep LISTEN | grep -q ":$WEAVIATE_GRPC_PORT"; then
+    if is_port_in_use "$WEAVIATE_GRPC_PORT"; then
         echo_red "Port $WEAVIATE_GRPC_PORT is already in use by another process."
         exit 1
     fi
-    if lsof -i -n -P | grep LISTEN | grep -q ":$WEAVIATE_METRICS"; then
+    if is_port_in_use "$WEAVIATE_METRICS"; then
         echo_red "Port $WEAVIATE_METRICS is already in use by another process."
         exit 1
     fi
-    if lsof -i -n -P | grep LISTEN | grep -q ":$PROFILER_PORT"; then
+    if is_port_in_use "$PROFILER_PORT"; then
         echo_red "Port $PROFILER_PORT is already in use by another process."
         exit 1
     fi
@@ -386,23 +394,23 @@ function verify_ports_available() {
         # Check if ports are available for each replica
         for i in $(seq 0 $((replicas-1))); do
             # Check Weaviate exposed port
-            if lsof -i -n -P | grep LISTEN | grep -q ":$((WEAVIATE_PORT+i+1))"; then
+            if is_port_in_use "$((WEAVIATE_PORT+i+1))"; then
                 echo_red "Port $((WEAVIATE_PORT+i+1)) is already in use"
                 exit 1
             fi
             # Check Weaviate grpc port
-            if lsof -i -n -P | grep LISTEN | grep -q ":$((WEAVIATE_GRPC_PORT+i+1))"; then
+            if is_port_in_use "$((WEAVIATE_GRPC_PORT+i+1))"; then
                 echo_red "Port $((WEAVIATE_GRPC_PORT+i+1)) is already in use"
                 exit 1
             fi
             # Check metrics port
-            if lsof -i -n -P | grep LISTEN | grep -q ":$((WEAVIATE_METRICS+i+1))"; then
+            if is_port_in_use "$((WEAVIATE_METRICS+i+1))"; then
                 echo_red "Port $((WEAVIATE_METRICS+i+1)) is already in use"
                 exit 1
             fi
 
             # Check profiler port
-            if lsof -i -n -P | grep LISTEN | grep -q ":$((PROFILER_PORT+i+1))"; then
+            if is_port_in_use "$((PROFILER_PORT+i+1))"; then
                 echo_red "Port $((PROFILER_PORT+i+1)) is already in use"
                 exit 1
             fi


### PR DESCRIPTION
## Problem

The port checks in `utilities/helpers.sh` used **unanchored substring matches** of the form:

```bash
lsof -i -n -P | grep LISTEN | grep -q ":$port"
```

Because `grep ":2114"` matches any listening socket whose port string *starts with* `2114` (e.g. `:21146`, `:21140`), an unrelated process on a high port could be mistaken for a Weaviate port. This bit a 3-node `EXPOSE_PODS` setup while an editor/dev-server was listening on `:21146` (node-1's metrics port is `2112+1+1 = 2114`), producing two distinct failures:

1. **Pre-flight check** (`verify_ports_available`) aborted setup with a bogus `Port 2114 is already in use`.
2. **Per-pod forwarding** (`ensure_krelay_forward`) silently skipped the forward, e.g. `Weaviate-1: METRICS=>2114(SKIPPED)` / `weaviate-1:2112->2114`.

All four port families (HTTP, gRPC, metrics, profiler) and both the default-port and per-replica checks were affected.

## Fix

Introduce an `is_port_in_use()` helper that anchors the match so the port number must be followed by a non-digit or end of line:

```bash
lsof -i -n -P | grep LISTEN | grep -qE ":${port}([^0-9]|$)"
```

- `verify_ports_available()` — the eight inline checks now call the helper.
- `ensure_krelay_forward()` — its three greps are anchored the same way (the relay-specific ones keep the `kubectl-r` filter; the "in use by something else" one reuses `is_port_in_use`).

## Test

New CI job `run-weaviate-local-k8s-substring-port` (REPLICAS=2, EXPOSE_PODS=true). It occupies several listeners whose port numbers merely *contain* a Weaviate port as a prefix, then asserts setup **succeeds** and that the affected ports are still forwarded:

- `21146` → `2114` (weaviate-1 metrics: pre-check loop + forward — the original symptom)
- `60616` → `6061` (weaviate-0 profiler: pre-check loop + forward)
- `21126` → `2112` (default metrics: pre-flight default-port check)

Verification: the cluster comes up (2 nodes on `:8080`), `:2114/metrics` returns 200 and is held by `kubectl-relay`, and `:6061` is reachable.

Note: only the metrics (`211xx`) and profiler (`606xx`) families are collidable — an HTTP (`8080x`) or gRPC (`50051x`) superset would exceed the 65535 port maximum. The complementary case (an *exact* listener must block setup) is already covered by the existing `run-weaviate-local-k8s-port-in-use` job.

## Scope

Unrelated to the namespaces work; scoped to the port-check substring bug and its regression test.