### PR TITLE
Add wcs-weaviate-operator as an alternative deployment method

### DIFF
--- a/.claude/skills/contributing-to-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/SKILL.md
@@ -13,10 +13,17 @@ Expert context for developing features, reviewing code, and maintaining quality 
 
 | File | Purpose | Lines |
 |------|---------|-------|
-| `local-k8s.sh` | Main entry point. Defines env vars, orchestrates setup/upgrade/clean | ~400 |
-| `utilities/helpers.sh` | All helper functions (helm values, port forwarding, health checks) | ~1070 |
-| `action.yml` | GitHub Actions composite action definition | ~200 |
-| `.github/workflows/main.yml` | CI test matrix (12 test jobs) | ~870 |
+| `local-k8s.sh` | Main entry point. Defines env vars, orchestrates setup/upgrade/clean | ~480 |
+| `utilities/helpers.sh` | All helper functions (helm values, port forwarding, health checks) | ~1100 |
+| `utilities/operator.sh` | wcs-weaviate-operator deployment method (DEPLOYMENT_METHOD=operator) | ~300 |
+| `action.yml` | GitHub Actions composite action definition | ~250 |
+| `.github/workflows/main.yml` | CI test matrix (19 test jobs) | ~1400 |
+
+Two deployment methods exist: `helm` (default, weaviate-helm chart) and `operator`
+(wcs-weaviate-operator; installs cert-manager + the operator and applies a Weaviate
+CR named `weaviate`, producing the same k8s resource names as the chart). The
+methods are mutually exclusive; helm-only options are rejected by
+`validate_operator_config()` in `utilities/operator.sh`.
 
 ### Data Flow: Env Var to Cluster
 
@@ -135,6 +142,9 @@ In `use_local_images()`, add case block:
 6. **Idempotency**: `setup()` and `upgrade()` should handle re-runs gracefully
 7. **Error handling**: `set -eou pipefail` is active. Failed commands exit immediately.
 8. **action.yml parity**: Every env var must have a matching action input
+9. **Deployment-method awareness**: New features must either work with both `helm`
+   and `operator` methods, or be explicitly rejected in `validate_operator_config()`
+   (utilities/operator.sh) when helm-only. Helm values never leak into the Weaviate CR.
 
 ### Common Mistakes
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/SKILL.md
@@ -17,7 +17,7 @@ Expert context for developing features, reviewing code, and maintaining quality 
 | `utilities/helpers.sh` | All helper functions (helm values, port forwarding, health checks) | ~1100 |
 | `utilities/operator.sh` | wcs-weaviate-operator deployment method (DEPLOYMENT_METHOD=operator) | ~300 |
 | `action.yml` | GitHub Actions composite action definition | ~250 |
-| `.github/workflows/main.yml` | CI test matrix (19 test jobs) | ~1400 |
+| `.github/workflows/main.yml` | CI test matrix (~20 test jobs) | ~1400 |
 
 Two deployment methods exist: `helm` (default, weaviate-helm chart) and `operator`
 (wcs-weaviate-operator; installs cert-manager + the operator and applies a Weaviate

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
@@ -6,10 +6,11 @@ File structure, function signatures, naming conventions, and data flow.
 
 ```
 weaviate-local-k8s/
-  local-k8s.sh          # Main entry point (~400 lines)
+  local-k8s.sh          # Main entry point (~480 lines)
   utilities/
-    helpers.sh           # All helper functions (~1070 lines)
-  action.yml             # GitHub Actions composite action (~200 lines)
+    helpers.sh           # All helper functions (~1100 lines)
+    operator.sh          # wcs-weaviate-operator deployment helpers (~300 lines)
+  action.yml             # GitHub Actions composite action (~250 lines)
   .github/workflows/
     main.yml             # CI test matrix (~870 lines)
   manifests/
@@ -120,6 +121,34 @@ User sets env vars (RBAC=true, REPLICAS=3, etc.)
 | `start/stop_weaviate_pod_state_logger()` | Background pod state tracking |
 | `echo_green/yellow/red()` | Colored output helpers |
 | `show_help()` | CLI help text |
+
+## operator.sh Function Map (DEPLOYMENT_METHOD=operator)
+
+`utilities/operator.sh` is sourced by `local-k8s.sh` and implements the
+wcs-weaviate-operator deployment method. `setup()`/`upgrade()` branch on
+`$DEPLOYMENT_METHOD`: the helm path calls `setup_helm` + `generate_helm_values` +
+`helm upgrade`; the operator path calls the functions below. Everything else
+(Kind cluster, MinIO/Keycloak/monitoring, port forwarding, health checks) is
+shared between both methods.
+
+| Function | Purpose |
+|----------|---------|
+| `validate_operator_config()` | Rejects helm-only options (HELM_BRANCH, VALUES_INLINE, AUTH_CONFIG, DELETE_STS, MCP, S3_OFFLOAD, COLLECTION_EXPORT; values-override.yaml only warns), enforces replicas 1/odd>=3, checks git/docker/yq |
+| `setup_cert_manager()` | Installs cert-manager (operator webhooks need it, failurePolicy=Fail) |
+| `setup_operator()` | Resolves sources (OPERATOR_DIR > clone OPERATOR_BRANCH), resolves image (OPERATOR_IMAGE or docker build), kind-loads, renders dist/install.yaml (image replace + ServiceMonitor strip when CRD absent), applies with retries, waits for controller |
+| `create_minio_credentials_secret()` | Secret consumed by spec.cloudAuth.aws.credentials |
+| `generate_weaviate_cr()` | Env vars -> /tmp/weaviate-cr.yaml (yq-built), merges cr-override.yaml |
+| `deploy_weaviate_cr()` | kubectl apply with retries (webhook warm-up) |
+| `wait_for_operator_sts_image()` | Upgrade: waits until the operator reconciles the new image into the STS template |
+| `wait_for_weaviate_cr_ready()` | kubectl wait --for=condition=Ready on the CR |
+| `log_operator_debug_info()` | CR yaml + operator pods/logs dump on failure |
+
+Key invariant: the CR is named `weaviate` in namespace `weaviate`, so the operator
+produces `sts/weaviate`, `svc/weaviate`, `svc/weaviate-grpc` and configmap
+`weaviate-cm` — the same names as the helm chart — keeping all shared helpers
+working. The operator always enables API key auth via a secretKeyRef
+(`weaviate-operator-admin-key` secret); `get_bearer_token()` in helpers.sh
+resolves it.
 
 ## Naming Conventions
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
@@ -139,10 +139,11 @@ shared between both methods.
 | `setup_cert_manager()` | Installs cert-manager (operator webhooks need it, failurePolicy=Fail) |
 | `setup_operator()` | Resolves sources (OPERATOR_DIR > clone OPERATOR_BRANCH), resolves image (OPERATOR_IMAGE or docker build), kind-loads, renders dist/install.yaml (image replace + ServiceMonitor strip when CRD absent), applies with retries, waits for controller |
 | `create_minio_credentials_secret()` | Secret consumed by spec.cloudAuth.aws.credentials |
-| `deploy_operator_module_services()` | Deploys the inference Deployment+Service for local vectorizers the operator does not ship — `text2vec-transformers` -> `manifests/transformers-inference.yaml`, `text2vec-model2vec` -> `manifests/model2vec-inference.yaml` (idempotent kubectl apply; called before the CR in setup/upgrade) |
-| `generate_weaviate_cr()` | Env vars -> /tmp/weaviate-cr.yaml (yq-built), merges cr-override.yaml. For local vectorizer MODULES also appends `TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API` to `spec.podConfig.extraEnv` pointing at the in-cluster service |
+| `deploy_operator_module_services()` | Deploys the inference Deployment+Service for local vectorizers the operator does not ship — `text2vec-transformers` -> `manifests/transformers-inference.yaml`, `text2vec-model2vec` -> `manifests/model2vec-inference.yaml` (idempotent kubectl apply; called before the CR in setup) |
+| `generate_weaviate_cr()` | Env vars -> /tmp/weaviate-cr.yaml (yq-built), merges cr-override.yaml (setup only). For local vectorizer MODULES also appends `TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API` to `spec.podConfig.extraEnv` pointing at the in-cluster service |
 | `deploy_weaviate_cr()` | kubectl apply with retries (webhook warm-up) |
-| `wait_for_operator_sts_image()` | Upgrade: waits until the operator reconciles the new image into the STS template |
+| `upgrade_weaviate_via_operator()` | Upgrade path: creates an `Upgrade` CR (`/tmp/weaviate-upgrade.yaml`, version-only) — the operator's canonical mechanism. `skipBackups: true` unless `OPERATOR_UPGRADE_BACKUP=true` (then `backend: s3`, needs `ENABLE_BACKUP=true`). Clears prior Upgrades (webhook single-flight), applies with retries |
+| `wait_for_upgrade_cr_complete()` | Polls `Upgrade.status.phase` until `Success`; aborts on `Failed`/`Cancelled`/timeout (scales with REPLICAS) |
 | `wait_for_weaviate_cr_ready()` | kubectl wait --for=condition=Ready on the CR |
 | `log_operator_debug_info()` | CR yaml + operator pods/logs dump on failure |
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/architecture.md
@@ -19,6 +19,8 @@ weaviate-local-k8s/
     keycloak-weaviate-realm.json  # Keycloak realm config for OIDC
     grafana-renderer.yaml         # Grafana renderer deployment
     metrics-server.yaml           # Metrics server deployment
+    transformers-inference.yaml   # text2vec-transformers inference svc (operator mode)
+    model2vec-inference.yaml      # text2vec-model2vec inference svc (operator mode)
     grafana-dashboards/           # 15+ Grafana dashboard JSON files
   scripts/
     create_oidc_user.sh  # Create Keycloak user
@@ -137,7 +139,8 @@ shared between both methods.
 | `setup_cert_manager()` | Installs cert-manager (operator webhooks need it, failurePolicy=Fail) |
 | `setup_operator()` | Resolves sources (OPERATOR_DIR > clone OPERATOR_BRANCH), resolves image (OPERATOR_IMAGE or docker build), kind-loads, renders dist/install.yaml (image replace + ServiceMonitor strip when CRD absent), applies with retries, waits for controller |
 | `create_minio_credentials_secret()` | Secret consumed by spec.cloudAuth.aws.credentials |
-| `generate_weaviate_cr()` | Env vars -> /tmp/weaviate-cr.yaml (yq-built), merges cr-override.yaml |
+| `deploy_operator_module_services()` | Deploys the inference Deployment+Service for local vectorizers the operator does not ship — `text2vec-transformers` -> `manifests/transformers-inference.yaml`, `text2vec-model2vec` -> `manifests/model2vec-inference.yaml` (idempotent kubectl apply; called before the CR in setup/upgrade) |
+| `generate_weaviate_cr()` | Env vars -> /tmp/weaviate-cr.yaml (yq-built), merges cr-override.yaml. For local vectorizer MODULES also appends `TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API` to `spec.podConfig.extraEnv` pointing at the in-cluster service |
 | `deploy_weaviate_cr()` | kubectl apply with retries (webhook warm-up) |
 | `wait_for_operator_sts_image()` | Upgrade: waits until the operator reconciles the new image into the STS template |
 | `wait_for_weaviate_cr_ready()` | kubectl wait --for=condition=Ready on the CR |

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/github-actions.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/github-actions.md
@@ -101,14 +101,18 @@ On failure, the action dumps:
 | `check-operator-token` | Gate: is WCS_OPERATOR_PAT configured? | secrets unavailable in job-level `if`, hence the gate job |
 | `run-weaviate-local-k8s-operator-basic` | Operator deployment | deployment-method=operator, REPLICAS=3 |
 | `run-weaviate-local-k8s-operator-features` | Operator + features | rbac, oidc, dynamic-users, backup, usage-s3, observability |
-| `run-weaviate-local-k8s-operator-upgrade` | Operator CR upgrade | 1.36.0 -> latest |
+| `run-weaviate-local-k8s-operator-upgrade` | Operator Upgrade CRD | 1.36.0 -> latest (skipBackups=true) |
+| `run-weaviate-local-k8s-operator-upgrade-backup` | Operator Upgrade CRD + backup | 1.36.0 -> latest, operator-upgrade-backup + enable-backup |
 | `run-weaviate-local-k8s-operator-prebuilt-image` | Pre-built controller image | operator-image + operator-dir (PR CI flow) |
 | `run-weaviate-local-k8s-operator-helm-incompatible` | Guard | operator + helm-branch must fail |
 
 The operator jobs (except the guard) `need` `check-operator-token` and skip when the
 `WCS_OPERATOR_PAT` secret is missing, because weaviate/wcs-weaviate-operator is a
 private repository. The action inputs for the operator path are `deployment-method`,
-`operator-branch`, `operator-image`, `operator-dir` and `github-token`.
+`operator-branch`, `operator-image`, `operator-dir`, `operator-upgrade-backup` and
+`github-token`. (`OPERATOR_REPO`, `CERT_MANAGER_VERSION` and `WEAVIATE_STORAGE_SIZE`
+are operator-internal env-var overrides for local runs, intentionally not exposed
+as action inputs.)
 
 ### Common Verification Pattern
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/github-actions.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/github-actions.md
@@ -98,6 +98,17 @@ On failure, the action dumps:
 | `run-weaviate-local-k8s-backup` | Backup functionality | ENABLE_BACKUP=true |
 | `run-weaviate-local-k8s-clean` | Clean operation | Verify cleanup works |
 | `run-weaviate-local-k8s-single-node` | Single node | WORKERS=0, REPLICAS=1 |
+| `check-operator-token` | Gate: is WCS_OPERATOR_PAT configured? | secrets unavailable in job-level `if`, hence the gate job |
+| `run-weaviate-local-k8s-operator-basic` | Operator deployment | deployment-method=operator, REPLICAS=3 |
+| `run-weaviate-local-k8s-operator-features` | Operator + features | rbac, oidc, dynamic-users, backup, usage-s3, observability |
+| `run-weaviate-local-k8s-operator-upgrade` | Operator CR upgrade | 1.36.0 -> latest |
+| `run-weaviate-local-k8s-operator-prebuilt-image` | Pre-built controller image | operator-image + operator-dir (PR CI flow) |
+| `run-weaviate-local-k8s-operator-helm-incompatible` | Guard | operator + helm-branch must fail |
+
+The operator jobs (except the guard) `need` `check-operator-token` and skip when the
+`WCS_OPERATOR_PAT` secret is missing, because weaviate/wcs-weaviate-operator is a
+private repository. The action inputs for the operator path are `deployment-method`,
+`operator-branch`, `operator-image`, `operator-dir` and `github-token`.
 
 ### Common Verification Pattern
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
@@ -23,7 +23,8 @@ Test coverage map, adding tests, and quality standards.
 | Operator basic | `run-weaviate-local-k8s-operator-basic` | DEPLOYMENT_METHOD=operator, 3 replicas, CR Ready, generated admin key, anonymous default, metrics, per-pod forwarding |
 | Operator features | `run-weaviate-local-k8s-operator-features` | Operator + RBAC (401 anonymous), OIDC (conf.yaml + keycloak), dynamic users, MinIO backup, USAGE_S3, observability |
 | Operator modules | `run-weaviate-local-k8s-operator-modules` | Operator + local vectorizers (text2vec-transformers, text2vec-model2vec): inference Deployments roll out, CR wires `*_INFERENCE_API` env, end-to-end vector produced per vectorizer |
-| Operator upgrade | `run-weaviate-local-k8s-operator-upgrade` | 1.36.0 -> latest by re-applying the CR (operator rolls the STS) |
+| Operator upgrade | `run-weaviate-local-k8s-operator-upgrade` | 1.36.0 -> latest via the operator's Upgrade CRD (default skipBackups=true, no backend); asserts Upgrade phase=Success |
+| Operator upgrade + backup | `run-weaviate-local-k8s-operator-upgrade-backup` | 1.36.0 -> latest via the Upgrade CRD with `operator-upgrade-backup=true` + `enable-backup=true`; asserts Success and a recorded `lastBackupName` |
 | Operator prebuilt image | `run-weaviate-local-k8s-operator-prebuilt-image` | Simulates the wcs-weaviate-operator PR CI flow: docker-build the controller, pass operator-image + operator-dir |
 | Operator guard | `run-weaviate-local-k8s-operator-helm-incompatible` | deployment-method=operator + helm-branch must fail fast (no token needed) |
 

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
@@ -22,6 +22,7 @@ Test coverage map, adding tests, and quality standards.
 | Operator token gate | `check-operator-token` | Exposes whether the `WCS_OPERATOR_PAT` secret exists (operator repo is private); operator jobs below skip when absent |
 | Operator basic | `run-weaviate-local-k8s-operator-basic` | DEPLOYMENT_METHOD=operator, 3 replicas, CR Ready, generated admin key, anonymous default, metrics, per-pod forwarding |
 | Operator features | `run-weaviate-local-k8s-operator-features` | Operator + RBAC (401 anonymous), OIDC (conf.yaml + keycloak), dynamic users, MinIO backup, USAGE_S3, observability |
+| Operator modules | `run-weaviate-local-k8s-operator-modules` | Operator + local vectorizers (text2vec-transformers, text2vec-model2vec): inference Deployments roll out, CR wires `*_INFERENCE_API` env, end-to-end vector produced per vectorizer |
 | Operator upgrade | `run-weaviate-local-k8s-operator-upgrade` | 1.36.0 -> latest by re-applying the CR (operator rolls the STS) |
 | Operator prebuilt image | `run-weaviate-local-k8s-operator-prebuilt-image` | Simulates the wcs-weaviate-operator PR CI flow: docker-build the controller, pass operator-image + operator-dir |
 | Operator guard | `run-weaviate-local-k8s-operator-helm-incompatible` | deployment-method=operator + helm-branch must fail fast (no token needed) |

--- a/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
+++ b/.claude/skills/contributing-to-weaviate-local-k8s/references/testing-quality.md
@@ -19,6 +19,12 @@ Test coverage map, adding tests, and quality standards.
 | OIDC | `run-weaviate-local-k8s-oidc` | Keycloak OIDC, user creation, token auth |
 | Port in use | `run-weaviate-local-k8s-port-in-use` | Port availability check fails when port occupied |
 | Substring port | `run-weaviate-local-k8s-substring-port` | Superset ports (e.g. 21146 vs 2114, 60616 vs 6061) do not block the pre-check or skip forwarding. Exact-port blocking is covered by `run-weaviate-local-k8s-port-in-use` |
+| Operator token gate | `check-operator-token` | Exposes whether the `WCS_OPERATOR_PAT` secret exists (operator repo is private); operator jobs below skip when absent |
+| Operator basic | `run-weaviate-local-k8s-operator-basic` | DEPLOYMENT_METHOD=operator, 3 replicas, CR Ready, generated admin key, anonymous default, metrics, per-pod forwarding |
+| Operator features | `run-weaviate-local-k8s-operator-features` | Operator + RBAC (401 anonymous), OIDC (conf.yaml + keycloak), dynamic users, MinIO backup, USAGE_S3, observability |
+| Operator upgrade | `run-weaviate-local-k8s-operator-upgrade` | 1.36.0 -> latest by re-applying the CR (operator rolls the STS) |
+| Operator prebuilt image | `run-weaviate-local-k8s-operator-prebuilt-image` | Simulates the wcs-weaviate-operator PR CI flow: docker-build the controller, pass operator-image + operator-dir |
+| Operator guard | `run-weaviate-local-k8s-operator-helm-incompatible` | deployment-method=operator + helm-branch must fail fast (no token needed) |
 
 ## Standard Verification Checks
 

--- a/.claude/skills/operating-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/operating-weaviate-local-k8s/SKILL.md
@@ -56,6 +56,10 @@ Rule: `WORKERS >= REPLICAS - 1` (control-plane counts as a node).
 | MCP server | `MCP_ENABLED=true` |
 | MCP with write access | `MCP_ENABLED=true MCP_WRITE_ACCESS_ENABLED=true` |
 | Test from local source | Build image + `--local-images` (see Build from Local Source) |
+| Deploy via wcs-weaviate-operator | `DEPLOYMENT_METHOD=operator` (see Operator Deployment) |
+| Operator from branch | `DEPLOYMENT_METHOD=operator OPERATOR_BRANCH="my-branch"` |
+| Operator pre-built image (PR testing) | `DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="img:tag"` |
+| Operator from local checkout | `DEPLOYMENT_METHOD=operator OPERATOR_DIR=~/repos/wcs-weaviate-operator` |
 
 ### Timeout Estimation
 
@@ -170,6 +174,47 @@ WEAVIATE_VERSION="1.28.0" MCP_ENABLED=true MCP_WRITE_ACCESS_ENABLED=true ./local
 ```bash
 WEAVIATE_VERSION="1.28.0" OBSERVABILITY=false ./local-k8s.sh setup
 ```
+
+### Operator Deployment (wcs-weaviate-operator)
+
+Deploy through the wcs-weaviate-operator instead of weaviate-helm. The script
+installs cert-manager + the operator and applies a `Weaviate` CR named `weaviate`
+(same resource names as helm: `sts/weaviate`, `svc/weaviate`, `svc/weaviate-grpc`).
+
+```bash
+# Default: clones + docker-builds the operator from main (private repo — needs
+# GH_TOKEN/GITHUB_TOKEN for https, or OPERATOR_REPO=git@github.com:... for SSH,
+# or OPERATOR_DIR pointing to a local checkout)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.36.8" REPLICAS=3 ./local-k8s.sh setup
+
+# Develop/test the operator itself from a local checkout
+DEPLOYMENT_METHOD=operator OPERATOR_DIR="$HOME/repos/wcs-weaviate-operator" \
+  WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Pre-built controller image (loaded into Kind if present locally)
+DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-123" \
+  WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Upgrade = re-apply the CR with the new version (operator rolls the STS)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 ./local-k8s.sh upgrade
+```
+
+Operator-mode rules:
+- `REPLICAS` must be 1 or an odd number >= 3 (webhook validation).
+- API key auth is ALWAYS enabled: admin user `weaviate-operator`, key in secret
+  `weaviate-operator-admin-key`. Get it:
+  `kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode`
+  Anonymous access stays on unless `RBAC=true` (helm parity).
+- Supported: `RBAC`, `OIDC`, `DYNAMIC_USERS`, `ENABLE_BACKUP`, `USAGE_S3`
+  (runtime overrides are always on in operator mode), `OBSERVABILITY`, `DASH0`,
+  `EXPOSE_PODS`, `WEAVIATE_IMAGE_PREFIX`, `--local-images`.
+- Rejected (helm-only): `HELM_BRANCH`, `VALUES_INLINE`, `AUTH_CONFIG`, `DELETE_STS`,
+  `MCP`, `S3_OFFLOAD`, `COLLECTION_EXPORT`. A `values-override.yaml` file is
+  ignored with a warning.
+- CR customization: `cr-override.yaml` next to the script (deep-merged into the
+  generated CR; see `cr-override.yaml.example`). Custom env vars go to
+  `spec.podConfig.extraEnv` there instead of `VALUES_INLINE`.
+- `MODULES` map to `spec.modules.extra`, but no inference sidecars are deployed.
 
 ### Build and Deploy from Local Weaviate Source
 

--- a/.claude/skills/operating-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/operating-weaviate-local-k8s/SKILL.md
@@ -214,7 +214,12 @@ Operator-mode rules:
 - CR customization: `cr-override.yaml` next to the script (deep-merged into the
   generated CR; see `cr-override.yaml.example`). Custom env vars go to
   `spec.podConfig.extraEnv` there instead of `VALUES_INLINE`.
-- `MODULES` map to `spec.modules.extra`, but no inference sidecars are deployed.
+- `MODULES` map to `spec.modules.extra`. For the local vectorizers
+  `text2vec-transformers` and `text2vec-model2vec`, weaviate-local-k8s also
+  deploys the inference service (from `manifests/`, what the helm chart would
+  create) and wires the CR `TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API`
+  env var to it. Other modules needing a companion deployment are enabled in the
+  CR but not functional (warned at setup).
 
 ### Build and Deploy from Local Weaviate Source
 

--- a/.claude/skills/operating-weaviate-local-k8s/SKILL.md
+++ b/.claude/skills/operating-weaviate-local-k8s/SKILL.md
@@ -220,6 +220,13 @@ Operator-mode rules:
   create) and wires the CR `TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API`
   env var to it. Other modules needing a companion deployment are enabled in the
   CR but not functional (warned at setup).
+- `upgrade` is driven through the operator's **Upgrade CRD** (its canonical
+  mechanism), not by re-applying the Weaviate CR. It is **version-only**: the
+  controller blocks downgrades, optionally backs up, patches the version and waits
+  for all pods to be healthy at the new version. Other config changes are NOT
+  re-applied on upgrade — edit the CR / `cr-override.yaml` or re-run setup for those.
+  Pre-upgrade backups are OFF by default; set `OPERATOR_UPGRADE_BACKUP=true`
+  (needs `ENABLE_BACKUP=true`) to take a backup first.
 
 ### Build and Deploy from Local Weaviate Source
 

--- a/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
@@ -242,6 +242,24 @@ DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-7" WEAVIATE_
 DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 ./local-k8s.sh upgrade
 ```
 
+### Local vectorizer modules in operator mode
+
+The operator configures Weaviate to use a vectorizer but does not deploy the
+companion inference server (the helm chart does). For `text2vec-transformers`
+and `text2vec-model2vec`, weaviate-local-k8s deploys it itself from
+`manifests/transformers-inference.yaml` / `manifests/model2vec-inference.yaml`
+(same images as the helm path, so `--local-images` is reused) and wires the CR's
+`spec.podConfig.extraEnv` to point Weaviate at the in-cluster service:
+
+```bash
+DEPLOYMENT_METHOD=operator MODULES="text2vec-transformers,text2vec-model2vec" \
+  WEAVIATE_VERSION="1.37.0" REPLICAS=1 ./local-k8s.sh setup
+```
+
+Resources live in the `weaviate` namespace, so `clean()` removes them with it.
+Other modules requiring a companion deployment are enabled in the CR but stay
+non-functional (warned at setup).
+
 Verification additions on top of the standard checks:
 
 ```bash
@@ -249,6 +267,8 @@ kubectl get weaviate weaviate -n weaviate                      # CR status/condi
 kubectl get secret weaviate-operator-admin-key -n weaviate \
   -o jsonpath='{.data.key}' | base64 --decode                  # generated admin key
 kubectl logs -n wcs-weaviate-operator-system deployment/wcs-weaviate-operator-controller-manager
+kubectl rollout status deployment/transformers-inference -n weaviate  # local vectorizer (if enabled)
+kubectl rollout status deployment/model2vec-inference -n weaviate     # local vectorizer (if enabled)
 ```
 
 Constraints: REPLICAS 1 or odd >= 3; helm-only options rejected; customize the CR

--- a/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
@@ -220,3 +220,36 @@ kubectl get all -n weaviate
 # Verify environment variables
 kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[0].env[*]}' | jq -r '.name'
 ```
+
+## Operator Deployment (DEPLOYMENT_METHOD=operator)
+
+Deploys Weaviate through the wcs-weaviate-operator instead of the helm chart:
+cert-manager is installed (operator webhooks), the operator is installed from
+`dist/install.yaml` of the resolved sources, and a `Weaviate` CR
+(`database.weaviate.io/v1alpha1`) named `weaviate` is applied. Resource names
+match the helm chart (`sts/weaviate`, `svc/weaviate`, `svc/weaviate-grpc`), so
+ports, health checks and `EXPOSE_PODS` behave identically.
+
+```bash
+# From main (clone + docker build; private repo: needs GH_TOKEN or SSH OPERATOR_REPO)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.36.8" REPLICAS=3 ./local-k8s.sh setup
+
+# From a local checkout / a pre-built image
+DEPLOYMENT_METHOD=operator OPERATOR_DIR=~/repos/wcs-weaviate-operator WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-7" WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Upgrade: re-apply the CR with the new version
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 ./local-k8s.sh upgrade
+```
+
+Verification additions on top of the standard checks:
+
+```bash
+kubectl get weaviate weaviate -n weaviate                      # CR status/conditions
+kubectl get secret weaviate-operator-admin-key -n weaviate \
+  -o jsonpath='{.data.key}' | base64 --decode                  # generated admin key
+kubectl logs -n wcs-weaviate-operator-system deployment/wcs-weaviate-operator-controller-manager
+```
+
+Constraints: REPLICAS 1 or odd >= 3; helm-only options rejected; customize the CR
+via `cr-override.yaml` (deep-merged). See the SKILL.md Operator Deployment section.

--- a/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/deployment-patterns.md
@@ -238,8 +238,34 @@ DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.36.8" REPLICAS=3 ./local-k8s.sh s
 DEPLOYMENT_METHOD=operator OPERATOR_DIR=~/repos/wcs-weaviate-operator WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
 DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-7" WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
 
-# Upgrade: re-apply the CR with the new version
+# Upgrade: driven through the operator's Upgrade CRD (version-only)
 DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 ./local-k8s.sh upgrade
+
+# Upgrade with a pre-upgrade backup (needs ENABLE_BACKUP=true for an s3 backend)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 \
+  ENABLE_BACKUP=true OPERATOR_UPGRADE_BACKUP=true ./local-k8s.sh upgrade
+```
+
+### Operator-mode upgrades (Upgrade CRD)
+
+`upgrade` in operator mode does NOT re-apply the Weaviate CR. It creates an
+`Upgrade` resource (`database.weaviate.io/v1alpha1`, named
+`weaviate-upgrade-<version>`) — the operator's canonical upgrade mechanism. The
+Upgrade controller blocks downgrades, optionally takes a backup, patches
+`weaviate.spec.version` and waits for every pod to be healthy at the new version
+before completing. The script polls `Upgrade.status.phase` until `Success` (and
+aborts on `Failed`/`Cancelled`). It is **version-only** — other config changes
+(modules, auth, resources) are not applied on upgrade; edit the CR /
+`cr-override.yaml` or re-run `setup` for those.
+
+Backups are off by default (`skipBackups: true`). `OPERATOR_UPGRADE_BACKUP=true`
+flips `skipBackups` to false and sets `backend: s3`, which requires a configured
+backup backend (`ENABLE_BACKUP=true`, i.e. MinIO). Verify:
+
+```bash
+kubectl get upgrades.database.weaviate.io -n weaviate
+kubectl get upgrade -n weaviate -o jsonpath='{.items[0].status.phase}'        # Success
+kubectl get upgrade -n weaviate -o jsonpath='{.items[0].status.lastBackupName}' # set when backed up
 ```
 
 ### Local vectorizer modules in operator mode

--- a/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
@@ -81,6 +81,26 @@ All are string `"true"` / `"false"`.
 | `MODULES` | `""` | Comma-separated module list |
 | `DOCKER_CONFIG` | `""` | Docker config file for pull secrets (absolute path, no `~`) |
 
+## Deployment Method (wcs-weaviate-operator)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEPLOYMENT_METHOD` | `"helm"` | `helm` (weaviate-helm chart) or `operator` (wcs-weaviate-operator) |
+| `OPERATOR_BRANCH` | `"main"` | Branch of wcs-weaviate-operator to clone and docker-build |
+| `OPERATOR_IMAGE` | `""` | Pre-built controller image (kind-loaded if present locally; skips the build) |
+| `OPERATOR_DIR` | `""` | Local wcs-weaviate-operator checkout to use instead of cloning |
+| `OPERATOR_REPO` | github https URL | Clone URL override (e.g. SSH remote for the private repo) |
+| `CERT_MANAGER_VERSION` | `"v1.18.2"` | cert-manager release installed for the operator webhooks |
+| `WEAVIATE_STORAGE_SIZE` | `"32Gi"` | PVC size in the generated Weaviate CR |
+
+Operator-mode rules: `REPLICAS` must be 1 or odd >= 3; helm-only options
+(`HELM_BRANCH`, `VALUES_INLINE`, `AUTH_CONFIG`, `DELETE_STS`,
+`MCP`, `S3_OFFLOAD`, `COLLECTION_EXPORT`) are rejected and a
+`values-override.yaml` file is ignored with a warning; `cr-override.yaml` deep-merges
+into the generated CR; the operator admin API key lives in the
+`weaviate-operator-admin-key` secret. Cloning the private repo over HTTPS uses
+`GH_TOKEN`/`GITHUB_TOKEN` when set.
+
 ## Authentication
 
 | Variable | Default | Description |

--- a/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
@@ -90,6 +90,7 @@ All are string `"true"` / `"false"`.
 | `OPERATOR_IMAGE` | `""` | Pre-built controller image (kind-loaded if present locally; skips the build) |
 | `OPERATOR_DIR` | `""` | Local wcs-weaviate-operator checkout to use instead of cloning |
 | `OPERATOR_REPO` | github https URL | Clone URL override (e.g. SSH remote for the private repo) |
+| `OPERATOR_UPGRADE_BACKUP` | `"false"` | Upgrade only: take a pre-upgrade backup via the Upgrade CRD (`skipBackups=false`). Requires `ENABLE_BACKUP=true` (MinIO/s3). Default disables backups |
 | `CERT_MANAGER_VERSION` | `"v1.18.2"` | cert-manager release installed for the operator webhooks |
 | `WEAVIATE_STORAGE_SIZE` | `"32Gi"` | PVC size in the generated Weaviate CR |
 
@@ -104,7 +105,10 @@ into the generated CR; the operator admin API key lives in the
 is applied from `manifests/` and the CR's `TRANSFORMERS_INFERENCE_API`/
 `MODEL2VEC_INFERENCE_API` is wired to it (the operator itself does not ship
 inference servers); other modules needing a companion deployment are enabled in the
-CR but not functional.
+CR but not functional. `upgrade` in operator mode is driven through the operator's
+Upgrade CRD (version-only; the controller blocks downgrades, optionally backs up,
+patches the version and waits for pods healthy at the new version) — set
+`OPERATOR_UPGRADE_BACKUP=true` (with `ENABLE_BACKUP=true`) to back up first.
 
 ## Authentication
 

--- a/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/environment-variables.md
@@ -99,7 +99,12 @@ Operator-mode rules: `REPLICAS` must be 1 or odd >= 3; helm-only options
 `values-override.yaml` file is ignored with a warning; `cr-override.yaml` deep-merges
 into the generated CR; the operator admin API key lives in the
 `weaviate-operator-admin-key` secret. Cloning the private repo over HTTPS uses
-`GH_TOKEN`/`GITHUB_TOKEN` when set.
+`GH_TOKEN`/`GITHUB_TOKEN` when set. For the local vectorizers in `MODULES`
+(`text2vec-transformers`, `text2vec-model2vec`), the inference Deployment + Service
+is applied from `manifests/` and the CR's `TRANSFORMERS_INFERENCE_API`/
+`MODEL2VEC_INFERENCE_API` is wired to it (the operator itself does not ship
+inference servers); other modules needing a companion deployment are enabled in the
+CR but not functional.
 
 ## Authentication
 

--- a/.claude/skills/operating-weaviate-local-k8s/references/modules-config.md
+++ b/.claude/skills/operating-weaviate-local-k8s/references/modules-config.md
@@ -51,6 +51,27 @@ WEAVIATE_VERSION="1.28.0" MODULES="text2vec-transformers-model2vec" ./local-k8s.
 
 Uses `semitechnologies/model2vec-inference` image with tag `minishlab-potion-multilingual-128M`. Special handling: overrides the `text2vec-transformers` Helm values (repo + tag) rather than using its own module path.
 
+## Local Vectorizers in Operator Mode
+
+In `DEPLOYMENT_METHOD=operator` the helm chart is not used, so the inference
+server that local vectorizers need is not created by the operator. For
+`text2vec-transformers` and `text2vec-model2vec`, weaviate-local-k8s deploys it
+from static manifests (`manifests/transformers-inference.yaml`,
+`manifests/model2vec-inference.yaml`) — same images as the helm path
+(`semitechnologies/transformers-inference:baai-bge-small-en-v1.5-onnx`,
+`semitechnologies/model2vec-inference:minishlab-potion-retrieval-32M`) so
+`--local-images` is reused — and wires the CR's
+`TRANSFORMERS_INFERENCE_API`/`MODEL2VEC_INFERENCE_API` env var to the service.
+
+```bash
+DEPLOYMENT_METHOD=operator MODULES="text2vec-transformers,text2vec-model2vec" \
+  WEAVIATE_VERSION="1.37.0" REPLICAS=1 ./local-k8s.sh setup
+```
+
+Other modules (e.g. `text2vec-contextionary`) are still added to
+`spec.modules.extra` but have no operator-deployed inference server and stay
+non-functional. See `deployment-patterns.md` for verification commands.
+
 ## Common Combinations
 
 ```bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,28 @@ jobs:
         - name: Retrieve latest Weaviate version
           id: latest-version
           uses: weaviate/github-common-actions/.github/actions/get-latest-weaviate-version@main
+    # weaviate/wcs-weaviate-operator is a private repository: the operator CI
+    # jobs need a token (WCS_OPERATOR_PAT secret) with read access to clone it.
+    # The secrets context is not available in job-level 'if' conditions, so a
+    # tiny gate job exposes whether the secret is configured. When it is not,
+    # the operator jobs are skipped instead of failing.
+    check-operator-token:
+      runs-on: ubuntu-latest
+      name: Check if the wcs-weaviate-operator token is configured
+      outputs:
+        has-token: ${{ steps.check.outputs.has-token }}
+      steps:
+        - name: Check for WCS_OPERATOR_PAT secret
+          id: check
+          env:
+            OPERATOR_TOKEN: ${{ secrets.WCS_OPERATOR_PAT }}
+          run: |
+            if [ -n "$OPERATOR_TOKEN" ]; then
+              echo "has-token=true" >> $GITHUB_OUTPUT
+            else
+              echo "has-token=false" >> $GITHUB_OUTPUT
+              echo "::warning::WCS_OPERATOR_PAT secret is not configured; skipping wcs-weaviate-operator CI jobs"
+            fi
     run-weaviate-local-k8s-basic:
       needs: get-latest-weaviate-version
       runs-on: ubuntu-latest
@@ -1057,28 +1079,6 @@ jobs:
             for pid in ${SQUAT_PIDS:-}; do
               kill "$pid" || true
             done
-    # weaviate/wcs-weaviate-operator is a private repository: the operator CI
-    # jobs need a token (WCS_OPERATOR_PAT secret) with read access to clone it.
-    # The secrets context is not available in job-level 'if' conditions, so a
-    # tiny gate job exposes whether the secret is configured. When it is not,
-    # the operator jobs are skipped instead of failing.
-    check-operator-token:
-      runs-on: ubuntu-latest
-      name: Check if the wcs-weaviate-operator token is configured
-      outputs:
-        has-token: ${{ steps.check.outputs.has-token }}
-      steps:
-        - name: Check for WCS_OPERATOR_PAT secret
-          id: check
-          env:
-            OPERATOR_TOKEN: ${{ secrets.WCS_OPERATOR_PAT }}
-          run: |
-            if [ -n "$OPERATOR_TOKEN" ]; then
-              echo "has-token=true" >> $GITHUB_OUTPUT
-            else
-              echo "has-token=false" >> $GITHUB_OUTPUT
-              echo "::warning::WCS_OPERATOR_PAT secret is not configured; skipping wcs-weaviate-operator CI jobs"
-            fi
     run-weaviate-local-k8s-operator-basic:
       needs: [get-latest-weaviate-version, check-operator-token]
       if: needs.check-operator-token.outputs.has-token == 'true'
@@ -1331,7 +1331,7 @@ jobs:
       needs: [get-latest-weaviate-version, check-operator-token]
       if: needs.check-operator-token.outputs.has-token == 'true'
       runs-on: ubuntu-latest
-      name: Invoke weaviate-local-k8s operator deployment and upgrade Weaviate via the CR
+      name: Invoke weaviate-local-k8s operator deployment and upgrade Weaviate via the Upgrade CRD
       env:
         WORKERS: '1'
         REPLICAS: '3'
@@ -1350,7 +1350,7 @@ jobs:
             replicas: ${{ env.REPLICAS }}
             weaviate-version: ${{ env.WEAVIATE_VERSION }}
             expose-pods: 'false'
-        - name: Upgrade Weaviate via the operator CR.
+        - name: Upgrade Weaviate via the operator Upgrade CRD.
           uses: ./
           with:
             operation: upgrade
@@ -1377,6 +1377,76 @@ jobs:
                     exit 1
                 fi
             done
+            # The upgrade must have been driven through the operator's Upgrade CRD
+            # (default path: skipBackups=true, no backup backend required).
+            upgrade_phase=$(kubectl get upgrades.database.weaviate.io -n weaviate -o jsonpath='{.items[0].status.phase}')
+            if [[ "$upgrade_phase" != "Success" ]]; then
+                echo "Error: expected an Upgrade CR in phase Success, found '$upgrade_phase'"
+                kubectl get upgrades.database.weaviate.io -n weaviate -o yaml
+                exit 1
+            fi
+    run-weaviate-local-k8s-operator-upgrade-backup:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s operator upgrade with a pre-upgrade backup (Upgrade CRD)
+      env:
+        WORKERS: '1'
+        REPLICAS: '1'
+        WEAVIATE_VERSION: '1.36.0'
+        UPGRADE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Deploy weaviate-local-k8s with the operator (backup backend enabled).
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            enable-backup: 'true'
+            expose-pods: 'false'
+        - name: Upgrade via the Upgrade CRD taking a pre-upgrade backup.
+          uses: ./
+          with:
+            operation: upgrade
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.UPGRADE_VERSION }}
+            enable-backup: 'true'
+            operator-upgrade-backup: 'true'
+            expose-pods: 'false'
+        - name: Check the upgrade succeeded and recorded a backup
+          run: |
+            set -ex
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=120s
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            versions=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/nodes | jq -r '.nodes[].version')
+            for version in $versions; do
+                if [[ "$version" != "${{ env.UPGRADE_VERSION }}" ]]; then
+                    echo "Error: Version is not equal to ${{ env.UPGRADE_VERSION }}. Found $version"
+                    exit 1
+                fi
+            done
+            # The Upgrade CR must have succeeded AND recorded a pre-upgrade backup
+            # (skipBackups=false because operator-upgrade-backup=true).
+            phase=$(kubectl get upgrades.database.weaviate.io -n weaviate -o jsonpath='{.items[0].status.phase}')
+            if [[ "$phase" != "Success" ]]; then
+                echo "Error: Upgrade CR phase is '$phase', expected Success"
+                kubectl get upgrades.database.weaviate.io -n weaviate -o yaml
+                exit 1
+            fi
+            backup_name=$(kubectl get upgrades.database.weaviate.io -n weaviate -o jsonpath='{.items[0].status.lastBackupName}')
+            if [[ -z "$backup_name" ]]; then
+                echo "Error: Upgrade did not record a backup (lastBackupName empty) despite operator-upgrade-backup=true"
+                kubectl get upgrades.database.weaviate.io -n weaviate -o yaml
+                exit 1
+            fi
+            echo "Upgrade succeeded with pre-upgrade backup: $backup_name"
     run-weaviate-local-k8s-operator-prebuilt-image:
       needs: [get-latest-weaviate-version, check-operator-token]
       if: needs.check-operator-token.outputs.has-token == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1057,4 +1057,322 @@ jobs:
             for pid in ${SQUAT_PIDS:-}; do
               kill "$pid" || true
             done
+    # weaviate/wcs-weaviate-operator is a private repository: the operator CI
+    # jobs need a token (WCS_OPERATOR_PAT secret) with read access to clone it.
+    # The secrets context is not available in job-level 'if' conditions, so a
+    # tiny gate job exposes whether the secret is configured. When it is not,
+    # the operator jobs are skipped instead of failing.
+    check-operator-token:
+      runs-on: ubuntu-latest
+      name: Check if the wcs-weaviate-operator token is configured
+      outputs:
+        has-token: ${{ steps.check.outputs.has-token }}
+      steps:
+        - name: Check for WCS_OPERATOR_PAT secret
+          id: check
+          env:
+            OPERATOR_TOKEN: ${{ secrets.WCS_OPERATOR_PAT }}
+          run: |
+            if [ -n "$OPERATOR_TOKEN" ]; then
+              echo "has-token=true" >> $GITHUB_OUTPUT
+            else
+              echo "has-token=false" >> $GITHUB_OUTPUT
+              echo "::warning::WCS_OPERATOR_PAT secret is not configured; skipping wcs-weaviate-operator CI jobs"
+            fi
+    run-weaviate-local-k8s-operator-basic:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s action deploying through the wcs-weaviate-operator
+      env:
+        WORKERS: '1'
+        REPLICAS: '3'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+        WEAVIATE_PORT: '8080'
+        WEAVIATE_GRPC_PORT: '50051'
+        EXPOSE_PODS: 'true'
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Deploy weaviate-local-k8s with the operator from current branch.
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            expose-pods: ${{ env.EXPOSE_PODS }}
+        - name: Check the configured values
+          run: |
+            set -ex
+            # The operator controller must be running
+            kubectl get deployment wcs-weaviate-operator-controller-manager -n wcs-weaviate-operator-system
+            # The Weaviate CR must report Ready
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=60s
+            replicas=$(kubectl get sts weaviate -n weaviate -o=jsonpath="{.spec.replicas}")
+            if [[ "$replicas" -ne ${{ env.REPLICAS }} ]]; then
+                echo "Error: Replicas count is not equal to ${{ env.REPLICAS }}. Found $replicas"
+                exit 1
+            fi
+            # The operator always enables API key auth with a generated admin key
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            if [[ -z "$ADMIN_KEY" ]]; then
+                echo "Error: weaviate-operator-admin-key secret is empty or missing"
+                exit 1
+            fi
+            # Anonymous access stays enabled by default (mirrors the helm chart)
+            curl -sf -o /dev/null http://127.0.0.1:8080/v1/.well-known/ready
+            versions=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/nodes | jq '.nodes[] | .version' | tr -d '"')
+            node_count=$(echo "$versions" | wc -l)
+            if [[ "$node_count" -ne ${{ env.REPLICAS }} ]]; then
+                echo "Error: Expected ${{ env.REPLICAS }} nodes, found $node_count"
+                exit 1
+            fi
+            for version in `echo $versions | tr '\n' ' '`; do
+                if [[ "$version" != "${{ env.WEAVIATE_VERSION }}" ]]; then
+                    echo "Error: Version is not equal to ${{ env.WEAVIATE_VERSION }}. Found $version"
+                    exit 1
+                fi
+            done
+            sleep 2 # Wait for the metrics to be available
+            error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:2112/metrics)
+            if [[ "$error" -ne 200 ]]; then
+              echo "Error: Weaviate metrics is not listening, returned $error"
+              exit 1
+            fi
+            # Pods must be individually exposed via kubectl-relay
+            for ((i=0; i<${{ env.REPLICAS }}; i++)); do
+              PORT=$((${{ env.WEAVIATE_PORT }} + i + 1))
+              GRPC_PORT=$((${{ env.WEAVIATE_GRPC_PORT }} + i + 1))
+              if [ -z "$(lsof -i :$PORT -sTCP:LISTEN -n -P | grep kubectl-r)" ]; then
+                echo "FAIL: Pod $i (HTTP Port $PORT): NOT LISTENING"
+                exit 1
+              fi
+              if [ -z "$(lsof -i :$GRPC_PORT -sTCP:LISTEN -n -P | grep kubectl-r)" ]; then
+                echo "FAIL: Pod $i (gRPC Port $GRPC_PORT): NOT LISTENING"
+                exit 1
+              fi
+            done
+    run-weaviate-local-k8s-operator-features:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s operator deployment with RBAC, OIDC, backup and usage
+      env:
+        WORKERS: '1'
+        REPLICAS: '1'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Deploy weaviate-local-k8s with the operator from current branch.
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            rbac: 'true'
+            oidc: 'true'
+            dynamic-users: 'true'
+            enable-backup: 'true'
+            usage-s3: 'true'
+            observability: 'true'
+            expose-pods: 'false'
+        - name: Check the configured values
+          run: |
+            set -ex
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=60s
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            # RBAC: anonymous access must be rejected...
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/v1/schema)
+            if [[ "$code" -ne 401 ]]; then
+                echo "Error: Anonymous request should return 401 with RBAC enabled, got $code"
+                exit 1
+            fi
+            # ...while the operator admin key has root access
+            curl -sf -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/schema > /dev/null
+            # conf.yaml rendered by the operator must contain RBAC and the keycloak OIDC issuer
+            config=$(kubectl get configmap weaviate-cm -n weaviate -o jsonpath='{.data.conf\.yaml}')
+            echo "$config" | grep -A2 "rbac" | grep -q "enabled: true"
+            echo "$config" | grep -q "keycloak.oidc.svc.cluster.local"
+            # Dynamic user management must be wired through the CR extraEnv
+            env_value=$(kubectl get sts weaviate -n weaviate -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTHENTICATION_DB_USERS_ENABLED")].value}')
+            if [[ "$env_value" != "true" ]]; then
+                echo "Error: AUTHENTICATION_DB_USERS_ENABLED is not true. Found $env_value"
+                exit 1
+            fi
+            # Usage collection must point at the MinIO bucket
+            env_value=$(kubectl get sts weaviate -n weaviate -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="USAGE_S3_BUCKET")].value}')
+            if [[ "$env_value" != "weaviate-usage" ]]; then
+                echo "Error: USAGE_S3_BUCKET is not weaviate-usage. Found $env_value"
+                exit 1
+            fi
+            # Create a dynamic db user
+            curl --fail-with-body -X POST -H "Authorization: Bearer $ADMIN_KEY" -H "Content-Type: application/json" \
+              http://127.0.0.1:8080/v1/users/db/ci-test-user
+            # Keycloak must be reachable and able to issue tokens
+            if ! grep -q "keycloak.oidc.svc.cluster.local" /etc/hosts; then
+                echo "Error: 127.0.0.1 keycloak.oidc.svc.cluster.local is not in /etc/hosts"
+                exit 1
+            fi
+            curl --fail -s -X POST -d grant_type=password -d client_id=demo -d username=admin -d password=admin \
+              http://keycloak.oidc.svc.cluster.local:9090/realms/weaviate/protocol/openid-connect/token | jq -r .access_token
+            # Backup to MinIO through the backup-s3 module configured by the CR
+            echo "Create a collection"
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $ADMIN_KEY" \
+              -d '{"class": "Article"}' \
+              http://127.0.0.1:8080/v1/schema
+            echo "Insert an object so the backup has data"
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $ADMIN_KEY" \
+              -d '{"class": "Article", "properties": {}}' \
+              http://127.0.0.1:8080/v1/objects
+            echo "Create a backup"
+            curl --fail-with-body -X POST -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $ADMIN_KEY" \
+              -d '{"id": "operator-test-backup"}' \
+              http://127.0.0.1:8080/v1/backups/s3
+            response=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/backups/s3/operator-test-backup)
+            if echo "$response" | jq -e '.status == "STARTED" or .status == "SUCCEEDED"' > /dev/null 2>&1; then
+              echo "The backup has been started."
+            else
+              echo "The backup status is not STARTED/SUCCEEDED or the json output is not the expected."
+              exit 1
+            fi
+            # Observability stack must be up
+            error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9091/metrics)
+            if [[ "$error" -ne 200 ]]; then
+              echo "Error: Prometheus is not listening, returned $error"
+              exit 1
+            fi
+            error=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/)
+            if [[ "$error" -ne 200 ]]; then
+              echo "Error: Grafana is not listening, returned $error"
+              exit 1
+            fi
+    run-weaviate-local-k8s-operator-upgrade:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s operator deployment and upgrade Weaviate via the CR
+      env:
+        WORKERS: '1'
+        REPLICAS: '3'
+        WEAVIATE_VERSION: '1.36.0'
+        UPGRADE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Deploy weaviate-local-k8s with the operator from current branch.
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            expose-pods: 'false'
+        - name: Upgrade Weaviate via the operator CR.
+          uses: ./
+          with:
+            operation: upgrade
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.UPGRADE_VERSION }}
+            expose-pods: 'false'
+        - name: Check the configured values
+          run: |
+            set -ex
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=120s
+            replicas=$(kubectl get sts weaviate -n weaviate -o=jsonpath="{.spec.replicas}")
+            if [[ "$replicas" -ne ${{ env.REPLICAS }} ]]; then
+                echo "Error: Replicas count is not equal to ${{ env.REPLICAS }}. Found $replicas"
+                exit 1
+            fi
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            versions=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/nodes | jq '.nodes[] | .version' | tr -d '"')
+            for version in `echo $versions | tr '\n' ' '`; do
+                if [[ "$version" != "${{ env.UPGRADE_VERSION }}" ]]; then
+                    echo "Error: Version is not equal to ${{ env.UPGRADE_VERSION }}. Found $version"
+                    exit 1
+                fi
+            done
+    run-weaviate-local-k8s-operator-prebuilt-image:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s operator deployment with a pre-built controller image
+      env:
+        WORKERS: '1'
+        REPLICAS: '1'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+        OPERATOR_IMAGE: 'wcs-weaviate-operator:ci-prebuilt'
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        # Simulates the wcs-weaviate-operator PR flow: its CI builds a
+        # controller image from the PR sources and hands the image plus the
+        # checkout to this action.
+        - name: Clone the operator repository and build the controller image
+          env:
+            GH_TOKEN: ${{ secrets.WCS_OPERATOR_PAT }}
+          run: |
+            git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/weaviate/wcs-weaviate-operator.git" /tmp/operator-src
+            docker build --build-arg VERSION=ci-prebuilt -t ${{ env.OPERATOR_IMAGE }} /tmp/operator-src
+        - name: Deploy weaviate-local-k8s with the pre-built operator image.
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            operator-image: ${{ env.OPERATOR_IMAGE }}
+            operator-dir: '/tmp/operator-src'
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            expose-pods: 'false'
+        - name: Check the configured values
+          run: |
+            set -ex
+            # The controller must run exactly the pre-built image
+            image=$(kubectl get deployment wcs-weaviate-operator-controller-manager -n wcs-weaviate-operator-system \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}')
+            if [[ "$image" != "${{ env.OPERATOR_IMAGE }}" ]]; then
+                echo "Error: Operator image is not ${{ env.OPERATOR_IMAGE }}. Found $image"
+                exit 1
+            fi
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=60s
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            curl -sf -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/nodes | jq -e '.nodes | length == 1'
+    run-weaviate-local-k8s-operator-helm-incompatible:
+      runs-on: ubuntu-latest
+      name: Verify operator deployment rejects helm-specific options
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        # The validation runs before the Kind cluster is created and before the
+        # private operator repo would be cloned, so no token is required here.
+        - name: Attempt operator deployment with helm-branch (should fail)
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            helm-branch: 'main'
+            replicas: '3'
+            weaviate-version: '1.36.0'
+            expose-pods: 'false'
+          continue-on-error: true
+        - name: Check that deployment failed
+          if: steps.invoke-local-k8s.outcome == 'success'
+          run: |
+            echo "The previous step should have failed (operator + helm-branch are incompatible), but it didn't"
+            exit 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1256,6 +1256,77 @@ jobs:
               echo "Error: Grafana is not listening, returned $error"
               exit 1
             fi
+    run-weaviate-local-k8s-operator-modules:
+      needs: [get-latest-weaviate-version, check-operator-token]
+      if: needs.check-operator-token.outputs.has-token == 'true'
+      runs-on: ubuntu-latest
+      name: Invoke weaviate-local-k8s operator deployment with local vectorizer modules
+      env:
+        WORKERS: '1'
+        REPLICAS: '1'
+        WEAVIATE_VERSION: ${{ needs.get-latest-weaviate-version.outputs.LATEST_WEAVIATE_VERSION }}
+        MODULES: 'text2vec-transformers,text2vec-model2vec'
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Deploy weaviate-local-k8s with the operator from current branch.
+          id: invoke-local-k8s
+          uses: ./
+          with:
+            deployment-method: 'operator'
+            github-token: ${{ secrets.WCS_OPERATOR_PAT }}
+            workers: ${{ env.WORKERS }}
+            replicas: ${{ env.REPLICAS }}
+            weaviate-version: ${{ env.WEAVIATE_VERSION }}
+            modules: ${{ env.MODULES }}
+            expose-pods: 'false'
+        - name: Check the configured values
+          run: |
+            set -ex
+            kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout=120s
+            # The operator does not ship module inference servers; weaviate-local-k8s
+            # must have deployed them for the local vectorizer modules.
+            kubectl rollout status deployment/transformers-inference -n weaviate --timeout=300s
+            kubectl rollout status deployment/model2vec-inference -n weaviate --timeout=300s
+            # Weaviate must be pointed at the in-cluster inference services via the CR
+            t_api=$(kubectl get sts weaviate -n weaviate -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TRANSFORMERS_INFERENCE_API")].value}')
+            if [[ "$t_api" != "http://transformers-inference:8080" ]]; then
+                echo "Error: TRANSFORMERS_INFERENCE_API is not set correctly. Found '$t_api'"
+                exit 1
+            fi
+            m_api=$(kubectl get sts weaviate -n weaviate -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="MODEL2VEC_INFERENCE_API")].value}')
+            if [[ "$m_api" != "http://model2vec-inference:8080" ]]; then
+                echo "Error: MODEL2VEC_INFERENCE_API is not set correctly. Found '$m_api'"
+                exit 1
+            fi
+            ADMIN_KEY=$(kubectl get secret weaviate-operator-admin-key -n weaviate -o jsonpath='{.data.key}' | base64 --decode)
+            # Both vectorizer modules must be advertised by Weaviate
+            modules=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" http://127.0.0.1:8080/v1/meta | jq -r '.modules | keys[]')
+            echo "$modules" | grep -q "text2vec-transformers"
+            echo "$modules" | grep -q "text2vec-model2vec"
+            # End-to-end: each local vectorizer must actually produce a vector
+            for vectorizer in text2vec-transformers text2vec-model2vec; do
+              class="Doc_${vectorizer//-/_}"
+              curl --fail-with-body -X POST -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $ADMIN_KEY" \
+                -d "{\"class\": \"$class\", \"vectorizer\": \"$vectorizer\", \"properties\": [{\"name\": \"text\", \"dataType\": [\"text\"]}]}" \
+                http://127.0.0.1:8080/v1/schema
+              id=$(curl -s -X POST -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $ADMIN_KEY" \
+                -d "{\"class\": \"$class\", \"properties\": {\"text\": \"the quick brown fox\"}}" \
+                http://127.0.0.1:8080/v1/objects | jq -r '.id')
+              if [[ -z "$id" || "$id" == "null" ]]; then
+                  echo "Error: object was not created for $vectorizer"
+                  exit 1
+              fi
+              vec_len=$(curl -s -H "Authorization: Bearer $ADMIN_KEY" \
+                "http://127.0.0.1:8080/v1/objects/$class/$id?include=vector" | jq '.vector | length')
+              if [[ -z "$vec_len" || "$vec_len" == "null" || "$vec_len" -lt 1 ]]; then
+                  echo "Error: $vectorizer did not produce a vector (length=$vec_len)"
+                  exit 1
+              fi
+              echo "$vectorizer produced a vector of length $vec_len"
+            done
     run-weaviate-local-k8s-operator-upgrade:
       needs: [get-latest-weaviate-version, check-operator-token]
       if: needs.check-operator-token.outputs.has-token == 'true'

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ This GitHub composite action allows you to deploy Weaviate to a local Kubernetes
 - **dynamic-users**: When set to true it will enable dynamic user management. Allowing the creation, deletion, activation, deactivation and key rotation of users. (Optional, default: 'false')
 - **auth-config**: File location containing the RBAC configuration in YAML format. (Optional, default: '')
 - **debug**: When set to true it will run the script in debug mode (set -x). (Optional, default: 'false')
+- **deployment-method**: How Weaviate is deployed: `helm` (weaviate-helm chart) or `operator` (wcs-weaviate-operator). (Optional, default: 'helm')
+- **operator-branch**: Branch of [weaviate/wcs-weaviate-operator](https://github.com/weaviate/wcs-weaviate-operator) to clone and build when `deployment-method=operator`. (Optional, default: 'main')
+- **operator-image**: Pre-built wcs-weaviate-operator controller image. If the image exists in the local Docker daemon it is loaded into Kind (useful for images built from a PR), otherwise the cluster pulls it. (Optional, default: '')
+- **operator-dir**: Path to a local wcs-weaviate-operator checkout to use instead of cloning. Use this from the operator repository's own CI to test PRs. (Optional, default: '')
+- **github-token**: Token with read access to the private wcs-weaviate-operator repository. Required when `deployment-method=operator` and no `operator-dir` is provided. (Optional, default: '')
 
 ### Usage
 To use this action in your GitHub Actions workflow, you can add the following step:
@@ -154,6 +159,10 @@ The environment variables that can be passed are:
 - **DASH0_API_ENDPOINT** (Dash0 API endpoint)
 - **HELM_TIMEOUT** (Timeout for Helm operations)
 - **HELM_REPO_UPDATE_TIMEOUT** (Timeout for Helm repo updates)
+- **DEPLOYMENT_METHOD** (`helm` or `operator`, default `helm`)
+- **OPERATOR_BRANCH** / **OPERATOR_IMAGE** / **OPERATOR_DIR** / **OPERATOR_REPO** (wcs-weaviate-operator source/image selection)
+- **CERT_MANAGER_VERSION** (cert-manager version installed for the operator webhooks)
+- **WEAVIATE_STORAGE_SIZE** (PVC size of the Weaviate CR in operator mode, default `32Gi`)
 Example, running preview version of Weaviate, using the `raft-configuration` weaviate-helm branch:
 ```bash
 WEAVIATE_VERSION="preview--d58d616" REPLICAS=5 WORKERS=3 HELM_BRANCH="raft-configuration" WEAVIATE_PORT="8081" ./local-k8s.sh setup
@@ -196,6 +205,81 @@ WORKERS=2 WEAVIATE_VERSION="1.25" REPLICAS=3 ./local-k8s.sh upgrade --local-imag
 ```
 
 Make sure your images are present in your environment, as otherwise the script will fail saying it can't locate those images locally. Simply run `docker pull semitechnologies/weaviate:${WEAVIATE_VERSION}`.
+
+### Deploying with the wcs-weaviate-operator
+
+As an alternative to the weaviate-helm chart, Weaviate can be deployed through the
+[wcs-weaviate-operator](https://github.com/weaviate/wcs-weaviate-operator) by setting
+`DEPLOYMENT_METHOD=operator`. The script then installs cert-manager (required by the
+operator's admission webhooks), installs the operator, and applies a `Weaviate` custom
+resource (`database.weaviate.io/v1alpha1`) named `weaviate`. The operator creates the
+same resource names as the helm chart (`sts/weaviate`, `svc/weaviate`,
+`svc/weaviate-grpc`), so port-forwarding and health checks behave identically.
+
+```bash
+# Deploy a 3 node cluster through the operator (clones + builds the operator from main)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.36.8" REPLICAS=3 ./local-k8s.sh setup
+
+# Use a specific operator branch
+DEPLOYMENT_METHOD=operator OPERATOR_BRANCH="my-feature" WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Use a pre-built operator image (e.g. built from a PR). If the image exists locally
+# it is loaded into Kind automatically.
+DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-123" WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Use a local operator checkout (no clone). Ideal for developing the operator itself.
+DEPLOYMENT_METHOD=operator OPERATOR_DIR="$HOME/repos/wcs-weaviate-operator" WEAVIATE_VERSION="1.36.8" ./local-k8s.sh setup
+
+# Upgrade the Weaviate version (the operator rolls the StatefulSet)
+DEPLOYMENT_METHOD=operator WEAVIATE_VERSION="1.37.0" REPLICAS=3 ./local-k8s.sh upgrade
+```
+
+Notes:
+
+- The wcs-weaviate-operator repository is **private**. When the sources need to be
+  cloned (no `OPERATOR_DIR`), provide a token via `GH_TOKEN`/`GITHUB_TOKEN`, or set
+  `OPERATOR_REPO=git@github.com:weaviate/wcs-weaviate-operator.git` to clone over SSH.
+- `REPLICAS` must be 1 or an odd number >= 3 (enforced by the operator's webhook for
+  raft quorum).
+- The operator always enables API key authentication with a generated admin key
+  (user `weaviate-operator`). The key is stored in the `weaviate-operator-admin-key`
+  secret and printed at the end of `setup`. Anonymous access remains enabled unless
+  `RBAC=true`, mirroring the helm defaults.
+- Supported features in operator mode: `RBAC`, `OIDC`, `DYNAMIC_USERS`,
+  `ENABLE_BACKUP` (MinIO S3), `USAGE_S3`, `OBSERVABILITY`, `DASH0`, `EXPOSE_PODS`,
+  `WEAVIATE_IMAGE_PREFIX` and `--local-images`.
+- Helm-only options are rejected: `HELM_BRANCH`, `VALUES_INLINE`, `AUTH_CONFIG`,
+  `DELETE_STS`, `MCP`, `S3_OFFLOAD`, `COLLECTION_EXPORT`. A local
+  `values-override.yaml` file is ignored (with a warning) in operator mode.
+- To customize the generated `Weaviate` CR, create a `cr-override.yaml` file next to
+  the script (see `cr-override.yaml.example`); it is deep-merged into the CR the same
+  way `values-override.yaml` works for helm.
+- `MODULES` are passed to `spec.modules.extra`, but the operator does not deploy
+  module inference sidecars (contextionary, transformers, ...), so modules requiring
+  a companion deployment will not be functional.
+
+In GitHub Actions workflows:
+
+```yaml
+# Testing a wcs-weaviate-operator PR from the operator repository CI:
+# build the controller image from the PR checkout and hand both to the action.
+- name: Checkout operator PR
+  uses: actions/checkout@v4
+- name: Build operator image
+  run: docker build --build-arg VERSION=pr -t wcs-weaviate-operator:pr .
+- name: Deploy Weaviate through the operator
+  uses: weaviate/weaviate-local-k8s@v2
+  with:
+    deployment-method: 'operator'
+    operator-image: 'wcs-weaviate-operator:pr'
+    operator-dir: ${{ github.workspace }}
+    weaviate-version: '1.36.8'
+    replicas: '3'
+```
+
+The CI jobs of this repository that exercise the operator path require a
+`WCS_OPERATOR_PAT` secret (a token with read access to wcs-weaviate-operator); when
+the secret is not configured those jobs are skipped.
 
 ### Invocation
 

--- a/action.yml
+++ b/action.yml
@@ -126,6 +126,26 @@ inputs:
     description: 'Whether or not to enable MCP write access (object upsert).'
     required: false
     default: 'false'
+  deployment-method:
+    description: 'How Weaviate is deployed: helm (weaviate-helm chart) or operator (wcs-weaviate-operator). Default: helm'
+    required: false
+    default: 'helm'
+  operator-branch:
+    description: 'Branch of weaviate/wcs-weaviate-operator to clone and build when deployment-method=operator'
+    required: false
+    default: 'main'
+  operator-image:
+    description: 'Pre-built wcs-weaviate-operator controller image. If present in the local Docker daemon it is loaded into Kind (useful for PR-built images), otherwise the cluster pulls it.'
+    required: false
+    default: ''
+  operator-dir:
+    description: 'Path to a local wcs-weaviate-operator checkout to use instead of cloning (e.g. the workspace checkout when running from the operator repository CI)'
+    required: false
+    default: ''
+  github-token:
+    description: 'Token with read access to weaviate/wcs-weaviate-operator (private). Required when deployment-method=operator and no operator-dir is provided.'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -173,6 +193,11 @@ runs:
         DOCKER_CONFIG: ${{ inputs.docker-config }}
         MCP: ${{ inputs.mcp }}
         MCP_WRITE_ACCESS: ${{ inputs.mcp-write-access }}
+        DEPLOYMENT_METHOD: ${{ inputs.deployment-method }}
+        OPERATOR_BRANCH: ${{ inputs.operator-branch }}
+        OPERATOR_IMAGE: ${{ inputs.operator-image }}
+        OPERATOR_DIR: ${{ inputs.operator-dir }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         # Retry configuration
         MAX_RETRIES=2
@@ -216,6 +241,14 @@ runs:
         kubectl get events -n weaviate || true
         echo "####### WEAVIATE STS CONFIG ######"
         kubectl get sts weaviate -n weaviate -o yaml || true
+        if [ "${{ inputs.deployment-method }}" = "operator" ]; then
+          echo "####### WEAVIATE CR ######"
+          kubectl get weaviate weaviate -n weaviate -o yaml || true
+          echo "####### OPERATOR PODS ######"
+          kubectl get deployment,pods -n wcs-weaviate-operator-system -o wide || true
+          echo "####### OPERATOR LOGS ######"
+          kubectl logs -n wcs-weaviate-operator-system deployment/wcs-weaviate-operator-controller-manager --tail=200 || true
+        fi
         echo "####### KUBECTL-RELAY PROCESSES ######"
         ps aux | grep kubectl-relay || echo "No kubectl-relay processes found" || true
         

--- a/action.yml
+++ b/action.yml
@@ -142,6 +142,10 @@ inputs:
     description: 'Path to a local wcs-weaviate-operator checkout to use instead of cloning (e.g. the workspace checkout when running from the operator repository CI)'
     required: false
     default: ''
+  operator-upgrade-backup:
+    description: 'Operator mode: take a backup before an upgrade via the Upgrade CRD (skipBackups=false). Requires enable-backup=true. Default: false (skipBackups=true).'
+    required: false
+    default: 'false'
   github-token:
     description: 'Token with read access to weaviate/wcs-weaviate-operator (private). Required when deployment-method=operator and no operator-dir is provided.'
     required: false
@@ -197,6 +201,7 @@ runs:
         OPERATOR_BRANCH: ${{ inputs.operator-branch }}
         OPERATOR_IMAGE: ${{ inputs.operator-image }}
         OPERATOR_DIR: ${{ inputs.operator-dir }}
+        OPERATOR_UPGRADE_BACKUP: ${{ inputs.operator-upgrade-backup }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
         # Retry configuration

--- a/cr-override.yaml.example
+++ b/cr-override.yaml.example
@@ -1,0 +1,24 @@
+# Example override for the Weaviate custom resource generated when
+# DEPLOYMENT_METHOD=operator. Copy this file to cr-override.yaml and adapt it;
+# it is deep-merged on top of the generated CR (maps are merged, arrays are
+# appended). This is the operator-mode counterpart of values-override.yaml.
+#
+# Full spec reference: https://github.com/weaviate/wcs-weaviate-operator
+spec:
+  podConfig:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+    storage:
+      size: 50Gi
+    extraEnv:
+      - name: ASYNC_INDEXING
+        value: "true"
+      - name: LOG_LEVEL
+        value: debug
+  config:
+    defaultVectorIndexType: hnsw

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -6,6 +6,8 @@ CURRENT_DIR="$(dirname "$0")"
 
 # Import functions from utilities.sh
 source "$CURRENT_DIR/utilities/helpers.sh"
+# Import wcs-weaviate-operator deployment helpers
+source "$CURRENT_DIR/utilities/operator.sh"
 
 REQUIREMENTS=(
     "kind"
@@ -72,6 +74,19 @@ MCP_WRITE_ACCESS=${MCP_WRITE_ACCESS:-"false"}
 DOCKER_CONFIG=${DOCKER_CONFIG:-""}
 ENABLE_RUNTIME_OVERRIDES=${ENABLE_RUNTIME_OVERRIDES:-"false"}
 RUNTIME_OVERRIDES_PATH=${RUNTIME_OVERRIDES_PATH:-"/config/overrides.yaml"}
+# Deployment method: 'helm' (weaviate-helm chart) or 'operator' (wcs-weaviate-operator)
+DEPLOYMENT_METHOD=${DEPLOYMENT_METHOD:-"helm"}
+OPERATOR_BRANCH=${OPERATOR_BRANCH:-"main"}
+OPERATOR_IMAGE=${OPERATOR_IMAGE:-""}
+OPERATOR_DIR=${OPERATOR_DIR:-""}
+OPERATOR_REPO=${OPERATOR_REPO:-"https://github.com/weaviate/wcs-weaviate-operator.git"}
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.18.2"}
+WEAVIATE_STORAGE_SIZE=${WEAVIATE_STORAGE_SIZE:-"32Gi"}
+
+if [[ "$DEPLOYMENT_METHOD" != "helm" && "$DEPLOYMENT_METHOD" != "operator" ]]; then
+    echo_red "Invalid DEPLOYMENT_METHOD: '$DEPLOYMENT_METHOD'. Supported values: helm, operator"
+    exit 1
+fi
 
 if [[ $DEBUG == "true" ]]; then
     set -x
@@ -99,12 +114,20 @@ function get_timeout() {
     if [ "$DASH0" == "true" ]; then
         modules_timeout=$((modules_timeout + 100))
     fi
+    if [ "$DEPLOYMENT_METHOD" == "operator" ]; then
+        # cert-manager + operator install/reconcile overhead
+        modules_timeout=$((modules_timeout + 300))
+    fi
 
     echo "$((modules_timeout + (REPLICAS * 100)))s"
 }
 
 function upgrade() {
-    echo_green "upgrade # Upgrading to Weaviate ${WEAVIATE_VERSION}"
+    echo_green "upgrade # Upgrading to Weaviate ${WEAVIATE_VERSION} (deployment method: $DEPLOYMENT_METHOD)"
+
+    if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
+        validate_operator_config
+    fi
 
     # Make sure to set the right context
     kubectl config use-context kind-weaviate-k8s
@@ -112,8 +135,10 @@ function upgrade() {
     # Upload images to cluster if --local-images flag is passed
     if [ "${1:-}" == "--local-images" ]; then
         use_local_images
-        # Make sure that the image.registry doesn't point to cr.weaviate.io, otherwise the local images won't be used
-        VALUES_INLINE="$VALUES_INLINE --set imagePullPolicy=Never --set image.registry=docker.io"
+        if [[ $DEPLOYMENT_METHOD == "helm" ]]; then
+            # Make sure that the image.registry doesn't point to cr.weaviate.io, otherwise the local images won't be used
+            VALUES_INLINE="$VALUES_INLINE --set imagePullPolicy=Never --set image.registry=docker.io"
+        fi
     fi
 
     if [[ $need_minio == "true" ]]; then
@@ -125,33 +150,45 @@ function upgrade() {
     stop_weaviate_pod_state_logger || true
     start_weaviate_pod_state_logger || true
 
-    # This function sets up weaviate-helm and sets the global env var $TARGET
-    setup_helm $HELM_BRANCH
-
-    if [ "$DELETE_STS" == "true" ]; then
-        echo_yellow "upgrade # Deleting Weaviate StatefulSet"
-        kubectl delete sts weaviate -n weaviate
+    if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
+        if [[ $need_minio == "true" ]]; then
+            create_minio_credentials_secret
+        fi
+        generate_weaviate_cr
+        echo_green "upgrade # Applying updated Weaviate CR through the wcs-weaviate-operator"
+        deploy_weaviate_cr
+        # The operator reconciles the CR change into the StatefulSet; wait for
+        # the pod template to reference the new image before watching rollout.
+        wait_for_operator_sts_image
     else
-        echo_green "upgrade # Weaviate StatefulSet is not being deleted"
+        # This function sets up weaviate-helm and sets the global env var $TARGET
+        setup_helm $HELM_BRANCH
+
+        if [ "$DELETE_STS" == "true" ]; then
+            echo_yellow "upgrade # Deleting Weaviate StatefulSet"
+            kubectl delete sts weaviate -n weaviate
+        else
+            echo_green "upgrade # Weaviate StatefulSet is not being deleted"
+        fi
+
+        HELM_VALUES=$(generate_helm_values)
+
+        VALUES_OVERRIDE=""
+        # Check if values-override.yaml file exists
+        if [ -f "${CURRENT_DIR}/values-override.yaml" ]; then
+            VALUES_OVERRIDE="-f ${CURRENT_DIR}/values-override.yaml"
+        fi
+
+        echo_green "upgrade # Upgrading weaviate-helm with values: \n\
+            TARGET: $TARGET \n\
+            HELM_VALUES: $(echo "$HELM_VALUES" | tr -s ' ') \n\
+            VALUES_OVERRIDE: $VALUES_OVERRIDE"
+        helm upgrade weaviate $TARGET  \
+            --namespace weaviate \
+            --timeout $HELM_TIMEOUT \
+            $HELM_VALUES \
+            $VALUES_OVERRIDE
     fi
-
-    HELM_VALUES=$(generate_helm_values)
-
-    VALUES_OVERRIDE=""
-    # Check if values-override.yaml file exists
-    if [ -f "${CURRENT_DIR}/values-override.yaml" ]; then
-        VALUES_OVERRIDE="-f ${CURRENT_DIR}/values-override.yaml"
-    fi
-
-    echo_green "upgrade # Upgrading weaviate-helm with values: \n\
-        TARGET: $TARGET \n\
-        HELM_VALUES: $(echo "$HELM_VALUES" | tr -s ' ') \n\
-        VALUES_OVERRIDE: $VALUES_OVERRIDE"
-    helm upgrade weaviate $TARGET  \
-        --namespace weaviate \
-        --timeout $HELM_TIMEOUT \
-        $HELM_VALUES \
-        $VALUES_OVERRIDE
 
     # Wait for Weaviate to be up
     # during the upgrade we don't need to wait for other modules to be ready, they should be already running
@@ -177,7 +214,10 @@ function upgrade() {
 
 
 function setup() {
-    echo_green "setup # Setting up Weaviate $WEAVIATE_VERSION on local k8s"
+    echo_green "setup # Setting up Weaviate $WEAVIATE_VERSION on local k8s (deployment method: $DEPLOYMENT_METHOD)"
+    if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
+        validate_operator_config
+    fi
     verify_ports_available $REPLICAS
     mount_config=""
     if [ "${DOCKER_CONFIG}" != "" ]; then
@@ -205,8 +245,10 @@ EOF
     # Upload images to cluster if --local-images flag is passed
     if [ "${1:-}" == "--local-images" ]; then
         use_local_images
-        # Make sure that the image.registry doesn't point to cr.weaviate.io, otherwise the local images won't be used
-        VALUES_INLINE="$VALUES_INLINE --set imagePullPolicy=Never --set image.registry=docker.io"
+        if [[ $DEPLOYMENT_METHOD == "helm" ]]; then
+            # Make sure that the image.registry doesn't point to cr.weaviate.io, otherwise the local images won't be used
+            VALUES_INLINE="$VALUES_INLINE --set imagePullPolicy=Never --set image.registry=docker.io"
+        fi
     fi
 
     # Create namespace
@@ -220,7 +262,9 @@ EOF
         startup_minio
     fi
 
-    if [[ $USAGE_S3 == "true" ]] && [[ $ENABLE_RUNTIME_OVERRIDES != "true" ]]; then
+    # The operator always enables runtime overrides, so the requirement only
+    # applies to the helm deployment method.
+    if [[ $USAGE_S3 == "true" ]] && [[ $ENABLE_RUNTIME_OVERRIDES != "true" ]] && [[ $DEPLOYMENT_METHOD == "helm" ]]; then
         echo_red "Must set ENABLE_RUNTIME_OVERRIDES if USAGE_S3 is enabled"
         exit 1
     fi
@@ -234,8 +278,10 @@ EOF
         startup_keycloak
     fi
 
-    # This function sets up weaviate-helm and sets the global env var $TARGET
-    setup_helm $HELM_BRANCH
+    if [[ $DEPLOYMENT_METHOD == "helm" ]]; then
+        # This function sets up weaviate-helm and sets the global env var $TARGET
+        setup_helm $HELM_BRANCH
+    fi
 
     # Setup monitoring in the weaviate cluster
     if [[ $OBSERVABILITY == "true" ]]; then
@@ -247,25 +293,36 @@ EOF
         setup_dash0
     fi
 
-    VALUES_OVERRIDE=""
-    # Check if values-override.yaml file exists
-    if [ -f "${CURRENT_DIR}/values-override.yaml" ]; then
-        VALUES_OVERRIDE="-f ${CURRENT_DIR}/values-override.yaml"
+    if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
+        setup_cert_manager
+        setup_operator
+        if [[ $need_minio == "true" ]]; then
+            create_minio_credentials_secret
+        fi
+        generate_weaviate_cr
+        echo_green "setup # Deploying Weaviate through the wcs-weaviate-operator"
+        deploy_weaviate_cr
+    else
+        VALUES_OVERRIDE=""
+        # Check if values-override.yaml file exists
+        if [ -f "${CURRENT_DIR}/values-override.yaml" ]; then
+            VALUES_OVERRIDE="-f ${CURRENT_DIR}/values-override.yaml"
+        fi
+
+        HELM_VALUES=$(generate_helm_values)
+
+        echo_green "setup # Deploying weaviate-helm with values: \n\
+            TARGET: $TARGET \n\
+            HELM_VALUES: $(echo "$HELM_VALUES" | tr -s ' ') \n\
+            VALUES_OVERRIDE: $VALUES_OVERRIDE"
+        # Install Weaviate using Helm
+        helm upgrade --install weaviate $TARGET \
+        --namespace weaviate \
+        --timeout $HELM_TIMEOUT \
+        $HELM_VALUES \
+        $VALUES_OVERRIDE
+        #--set debug=true
     fi
-
-    HELM_VALUES=$(generate_helm_values)
-
-    echo_green "setup # Deploying weaviate-helm with values: \n\
-        TARGET: $TARGET \n\
-        HELM_VALUES: $(echo "$HELM_VALUES" | tr -s ' ') \n\
-        VALUES_OVERRIDE: $VALUES_OVERRIDE"
-    # Install Weaviate using Helm
-    helm upgrade --install weaviate $TARGET \
-    --namespace weaviate \
-    --timeout $HELM_TIMEOUT \
-    $HELM_VALUES \
-    $VALUES_OVERRIDE
-    #--set debug=true
 
 
     # Wait for Weaviate to be up
@@ -280,6 +337,9 @@ EOF
     done
     echo_green "setup # Waiting (with timeout=$TIMEOUT) for Weaviate $REPLICAS node cluster to be ready"
     kubectl wait sts/weaviate -n weaviate --for jsonpath='{.status.readyReplicas}'=${REPLICAS} --timeout=${TIMEOUT}
+    if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
+        wait_for_weaviate_cr_ready 300s
+    fi
     port_forward_to_weaviate $REPLICAS
     if [[ $EXPOSE_PODS == "true" ]]; then
         port_forward_weaviate_pods
@@ -347,6 +407,12 @@ function clean() {
 
     # Make sure to set the right context
     kubectl config use-context kind-weaviate-k8s
+
+    # Delete the Weaviate CR first if the wcs-weaviate-operator deployed it,
+    # so the operator can tear down its resources before the namespace goes.
+    if kubectl get weaviate weaviate -n weaviate &> /dev/null; then
+        kubectl delete weaviate weaviate -n weaviate --timeout=120s || true
+    fi
 
     # Check if Weaviate release exists
     if helm status weaviate -n weaviate &> /dev/null; then

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -154,6 +154,8 @@ function upgrade() {
         if [[ $need_minio == "true" ]]; then
             create_minio_credentials_secret
         fi
+        # Idempotent: ensures the module inference servers exist after upgrade.
+        deploy_operator_module_services
         generate_weaviate_cr
         echo_green "upgrade # Applying updated Weaviate CR through the wcs-weaviate-operator"
         deploy_weaviate_cr
@@ -299,6 +301,9 @@ EOF
         if [[ $need_minio == "true" ]]; then
             create_minio_credentials_secret
         fi
+        # The operator does not deploy module inference servers; do it ourselves
+        # before the CR so they are warming up while Weaviate starts.
+        deploy_operator_module_services
         generate_weaviate_cr
         echo_green "setup # Deploying Weaviate through the wcs-weaviate-operator"
         deploy_weaviate_cr

--- a/local-k8s.sh
+++ b/local-k8s.sh
@@ -80,6 +80,10 @@ OPERATOR_BRANCH=${OPERATOR_BRANCH:-"main"}
 OPERATOR_IMAGE=${OPERATOR_IMAGE:-""}
 OPERATOR_DIR=${OPERATOR_DIR:-""}
 OPERATOR_REPO=${OPERATOR_REPO:-"https://github.com/weaviate/wcs-weaviate-operator.git"}
+# Operator-mode upgrades go through the operator's Upgrade CRD. Pre-upgrade
+# backups are disabled by default (skipBackups: true); set to "true" to take a
+# backup before the version change (requires a backup backend, i.e. ENABLE_BACKUP=true).
+OPERATOR_UPGRADE_BACKUP=${OPERATOR_UPGRADE_BACKUP:-"false"}
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.18.2"}
 WEAVIATE_STORAGE_SIZE=${WEAVIATE_STORAGE_SIZE:-"32Gi"}
 
@@ -151,17 +155,12 @@ function upgrade() {
     start_weaviate_pod_state_logger || true
 
     if [[ $DEPLOYMENT_METHOD == "operator" ]]; then
-        if [[ $need_minio == "true" ]]; then
-            create_minio_credentials_secret
-        fi
-        # Idempotent: ensures the module inference servers exist after upgrade.
-        deploy_operator_module_services
-        generate_weaviate_cr
-        echo_green "upgrade # Applying updated Weaviate CR through the wcs-weaviate-operator"
-        deploy_weaviate_cr
-        # The operator reconciles the CR change into the StatefulSet; wait for
-        # the pod template to reference the new image before watching rollout.
-        wait_for_operator_sts_image
+        # Version changes go through the operator's Upgrade CRD (its canonical
+        # mechanism: optional pre-upgrade backup, patches the Weaviate version
+        # and waits for every pod to be healthy at the new version). This is a
+        # version-only upgrade; other config changes are not re-applied here
+        # (edit the Weaviate CR / cr-override.yaml or re-run setup for those).
+        upgrade_weaviate_via_operator
     else
         # This function sets up weaviate-helm and sets the global env var $TARGET
         setup_helm $HELM_BRANCH

--- a/manifests/model2vec-inference.yaml
+++ b/manifests/model2vec-inference.yaml
@@ -1,0 +1,70 @@
+# text2vec-model2vec inference service for the operator deployment method.
+#
+# weaviate-helm ships this Deployment + Service as part of the chart
+# (templates/model2vecInferenceDeployment.yaml). The wcs-weaviate-operator
+# only configures Weaviate to USE a vectorizer module, it does not deploy the
+# companion inference server, so in DEPLOYMENT_METHOD=operator we apply this
+# manifest ourselves. generate_weaviate_cr() points Weaviate at it via the
+# MODEL2VEC_INFERENCE_API env var (http://model2vec-inference:8080).
+#
+# Image matches the tag the helm path and use_local_images() use, so
+# --local-images (kind load) is reused via imagePullPolicy: IfNotPresent.
+# model2vec is lightweight and (unlike transformers) takes no CUDA/env config.
+# Probe timings are tuned for local Kind (the chart defaults to a 120s initial
+# delay; the model here is small and loads in seconds).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model2vec-inference
+  namespace: weaviate
+  labels:
+    app: model2vec-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model2vec-inference
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: model2vec-inference
+    spec:
+      containers:
+        - name: model2vec-inference
+          image: semitechnologies/model2vec-inference:minishlab-potion-retrieval-32M
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /.well-known/ready
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /.well-known/live
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model2vec-inference
+  namespace: weaviate
+  labels:
+    app: model2vec-inference
+spec:
+  type: ClusterIP
+  selector:
+    app: model2vec-inference
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/manifests/transformers-inference.yaml
+++ b/manifests/transformers-inference.yaml
@@ -1,0 +1,72 @@
+# text2vec-transformers inference service for the operator deployment method.
+#
+# weaviate-helm ships this Deployment + Service as part of the chart
+# (templates/transformersInferenceDeployment.yaml). The wcs-weaviate-operator
+# only configures Weaviate to USE a vectorizer module, it does not deploy the
+# companion inference server, so in DEPLOYMENT_METHOD=operator we apply this
+# manifest ourselves. generate_weaviate_cr() points Weaviate at it via the
+# TRANSFORMERS_INFERENCE_API env var (http://transformers-inference:8080).
+#
+# Image matches the tag the helm path and use_local_images() use, so
+# --local-images (kind load) is reused via imagePullPolicy: IfNotPresent.
+# Probe timings are tuned for local Kind (the chart defaults to a 120s initial
+# delay; the models here are small and load in seconds).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transformers-inference
+  namespace: weaviate
+  labels:
+    app: transformers-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: transformers-inference
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: transformers-inference
+    spec:
+      containers:
+        - name: transformers-inference
+          image: semitechnologies/transformers-inference:baai-bge-small-en-v1.5-onnx
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ENABLE_CUDA
+              value: "0"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /.well-known/ready
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /.well-known/live
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: transformers-inference
+  namespace: weaviate
+  labels:
+    app: transformers-inference
+spec:
+  type: ClusterIP
+  selector:
+    app: transformers-inference
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -135,6 +135,30 @@ Environment Variables:
     DASH0_ENDPOINT              Dash0 export endpoint (default: "ingress.eu-west-1.aws.dash0.com:4317")
     DASH0_API_ENDPOINT          Dash0 API endpoint (default: "api.eu-west-1.aws.dash0.com")
 
+  Deployment Method:
+    DEPLOYMENT_METHOD   How Weaviate is deployed: 'helm' (weaviate-helm chart) or
+                        'operator' (wcs-weaviate-operator) (default: "helm")
+    OPERATOR_BRANCH     Branch of weaviate/wcs-weaviate-operator to clone and build
+                        when DEPLOYMENT_METHOD=operator (default: "main")
+    OPERATOR_IMAGE      Pre-built operator controller image to use instead of building
+                        from sources. If present in the local Docker daemon it is loaded
+                        into Kind, otherwise the cluster pulls it (default: "")
+    OPERATOR_DIR        Path to a local wcs-weaviate-operator checkout to use instead of
+                        cloning (useful when testing operator PRs) (default: "")
+    CERT_MANAGER_VERSION Version of cert-manager to install for the operator webhooks
+                        (default: "v1.18.2")
+    WEAVIATE_STORAGE_SIZE PVC size for the Weaviate CR in operator mode (default: "32Gi")
+
+    Notes for DEPLOYMENT_METHOD=operator:
+      * Incompatible with HELM_BRANCH, VALUES_INLINE, AUTH_CONFIG, DELETE_STS,
+        MCP, S3_OFFLOAD and COLLECTION_EXPORT (helm-only). A values-override.yaml
+        file is ignored (with a warning).
+      * REPLICAS must be 1 or an odd number >= 3 (operator webhook validation).
+      * API key auth is always enabled by the operator; the generated admin key is
+        stored in the 'weaviate-operator-admin-key' secret and printed after setup.
+      * Use a 'cr-override.yaml' file (same directory as the script) to customize the
+        generated Weaviate CR, analogous to values-override.yaml for helm.
+
   Deployment Options:
     MODULES            Comma-separated list of Weaviate modules to enable (default: "")
                        Available modules: https://weaviate.io/developers/weaviate/model-providers
@@ -169,6 +193,15 @@ Examples:
 
     # Setup with modules and backup enabled
     WEAVIATE_VERSION="1.28.0" MODULES="text2vec-transformers" ENABLE_BACKUP=true ./local-k8s.sh setup
+
+    # Setup using the wcs-weaviate-operator instead of weaviate-helm
+    WEAVIATE_VERSION="1.32.0" DEPLOYMENT_METHOD=operator REPLICAS=3 ./local-k8s.sh setup
+
+    # Operator from a specific branch
+    WEAVIATE_VERSION="1.32.0" DEPLOYMENT_METHOD=operator OPERATOR_BRANCH="my-feature" ./local-k8s.sh setup
+
+    # Operator using a pre-built controller image (e.g. built from a PR)
+    WEAVIATE_VERSION="1.32.0" DEPLOYMENT_METHOD=operator OPERATOR_IMAGE="wcs-weaviate-operator:pr-123" ./local-k8s.sh setup
 
     # Clean up all resources
     ./local-k8s.sh clean
@@ -320,6 +353,19 @@ function get_bearer_token() {
         return
     fi
 
+    # The wcs-weaviate-operator wires AUTHENTICATION_APIKEY_ALLOWED_KEYS via a
+    # secretKeyRef (random admin key in secret weaviate-operator-admin-key)
+    # instead of a literal value. Resolve the referenced secret in that case.
+    secret_name=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[*].env[?(@.name=="AUTHENTICATION_APIKEY_ALLOWED_KEYS")].valueFrom.secretKeyRef.name}')
+    secret_key=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[*].env[?(@.name=="AUTHENTICATION_APIKEY_ALLOWED_KEYS")].valueFrom.secretKeyRef.key}')
+    if [[ -n "$secret_name" ]] && [[ -n "$secret_key" ]]; then
+        secret_tokens=$(kubectl get secret "$secret_name" -n weaviate -o jsonpath="{.data.${secret_key}}" | base64 --decode)
+        IFS=',' read -r bearer_token _ <<< "$secret_tokens"
+        if [[ -n "$bearer_token" ]]; then
+            echo "$bearer_token"
+            return
+        fi
+    fi
 
     # Check configmap as fallback
     if kubectl get configmap -n weaviate weaviate-config &>/dev/null; then
@@ -906,6 +952,20 @@ TZEOF
     echo "$helm_values"
 }
 
+# Adds the prometheus-community Helm repo (with retries). Called from
+# setup_helm and from setup_monitoring so monitoring also works when Weaviate
+# is deployed through the wcs-weaviate-operator (which skips setup_helm).
+function ensure_prometheus_helm_repo () {
+    for i in {1..3}; do
+        if helm repo add prometheus-community https://prometheus-community.github.io/helm-charts; then
+            break
+        else
+            echo_yellow "Failed to add prometheus-community repo (attempt $i/3), retrying in 5s..."
+            sleep 5
+        fi
+    done
+}
+
 function setup_helm () {
     if [ $# -eq 0 ]; then
         HELM_BRANCH=""
@@ -916,14 +976,7 @@ function setup_helm () {
     echo_green "Adding Helm repositories with timeout settings"
 
     # Add prometheus-community repo with retry logic
-    for i in {1..3}; do
-        if helm repo add prometheus-community https://prometheus-community.github.io/helm-charts; then
-            break
-        else
-            echo_yellow "Failed to add prometheus-community repo (attempt $i/3), retrying in 5s..."
-            sleep 5
-        fi
-    done
+    ensure_prometheus_helm_repo
 
     if [ -n "${HELM_BRANCH:-}" ]; then
         WEAVIATE_HELM_DIR="/tmp/weaviate-helm"
@@ -965,6 +1018,9 @@ function setup_helm () {
 function setup_monitoring () {
 
     echo_green "Setting up monitoring"
+
+    # Required when deploying via the operator, where setup_helm is skipped
+    ensure_prometheus_helm_repo
 
     echo_green "*** Metrics API ***"
     # Start up metrics api

--- a/utilities/helpers.sh
+++ b/utilities/helpers.sh
@@ -359,7 +359,10 @@ function get_bearer_token() {
     secret_name=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[*].env[?(@.name=="AUTHENTICATION_APIKEY_ALLOWED_KEYS")].valueFrom.secretKeyRef.name}')
     secret_key=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[*].env[?(@.name=="AUTHENTICATION_APIKEY_ALLOWED_KEYS")].valueFrom.secretKeyRef.key}')
     if [[ -n "$secret_name" ]] && [[ -n "$secret_key" ]]; then
-        secret_tokens=$(kubectl get secret "$secret_name" -n weaviate -o jsonpath="{.data.${secret_key}}" | base64 --decode)
+        # Keep this non-fatal: under 'set -eou pipefail' a missing or temporarily
+        # unavailable secret (or a base64 decode error) would otherwise abort the
+        # whole script instead of letting us fall through to the configmap path.
+        secret_tokens=$(kubectl get secret "$secret_name" -n weaviate -o jsonpath="{.data.${secret_key}}" 2>/dev/null | base64 --decode 2>/dev/null || true)
         IFS=',' read -r bearer_token _ <<< "$secret_tokens"
         if [[ -n "$bearer_token" ]]; then
             echo "$bearer_token"

--- a/utilities/operator.sh
+++ b/utilities/operator.sh
@@ -10,6 +10,7 @@
 OPERATOR_NAMESPACE="wcs-weaviate-operator-system"
 OPERATOR_DEPLOYMENT="wcs-weaviate-operator-controller-manager"
 WEAVIATE_CR_FILE="/tmp/weaviate-cr.yaml"
+UPGRADE_CR_FILE="/tmp/weaviate-upgrade.yaml"
 MINIO_SECRET_NAME="minio-credentials"
 
 # Fail fast on configurations the operator cannot express. Everything listed
@@ -362,23 +363,104 @@ function deploy_weaviate_cr() {
     fi
 }
 
-# After an upgrade the operator has to reconcile the CR change into the
-# StatefulSet before 'kubectl rollout status' means anything. Wait until the
-# StatefulSet pod template references the expected weaviate image.
-function wait_for_operator_sts_image() {
-    local expected_image="${WEAVIATE_IMAGE_PREFIX}/weaviate:${WEAVIATE_VERSION}"
-    echo_green "Waiting for operator to roll StatefulSet to image ${expected_image}"
-    for _ in {1..60}; do
-        local current_image
-        current_image=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[?(@.name=="weaviate")].image}' 2>/dev/null || true)
-        if [[ "$current_image" == "$expected_image" ]]; then
-            echo_green "StatefulSet template updated to ${expected_image}"
-            return
+# Upgrades a running Weaviate to ${WEAVIATE_VERSION} through the operator's
+# Upgrade CRD (database.weaviate.io/v1alpha1 Upgrade) instead of patching the
+# Weaviate CR directly. This is the operator's canonical upgrade path: the
+# Upgrade controller optionally takes a backup, patches the Weaviate version and
+# waits for every pod to be healthy at the new version (it also blocks
+# downgrades and enforces single-flight). Only the version is changed here.
+#
+# Pre-upgrade backups are off by default (skipBackups: true). Set
+# OPERATOR_UPGRADE_BACKUP=true to take a backup first; that needs a backup
+# backend, which weaviate-local-k8s only wires up (MinIO/s3) when ENABLE_BACKUP=true.
+function upgrade_weaviate_via_operator() {
+    local skip_backups="true"
+    local backend_line=""
+    if [[ "$OPERATOR_UPGRADE_BACKUP" == "true" ]]; then
+        if [[ "$ENABLE_BACKUP" != "true" ]]; then
+            echo_red "OPERATOR_UPGRADE_BACKUP=true needs a backup backend; re-run the upgrade with ENABLE_BACKUP=true (MinIO/s3)."
+            exit 1
         fi
-        echo_yellow "StatefulSet image is '${current_image:-<none>}', waiting for operator reconcile..."
+        skip_backups="false"
+        backend_line="  backend: s3"
+        echo_green "upgrade # Pre-upgrade backup ENABLED (Upgrade CRD, backend: s3)"
+    else
+        echo_green "upgrade # Pre-upgrade backup disabled (Upgrade CRD, skipBackups: true)"
+    fi
+
+    # k8s object names must be RFC1123: lowercase, dots -> dashes.
+    local version_slug="${WEAVIATE_VERSION//./-}"
+    local upgrade_name="weaviate-upgrade-${version_slug}"
+
+    # The validating webhook allows only one in-flight Upgrade per Weaviate.
+    # Clear any previous Upgrade objects so repeated upgrades are idempotent.
+    kubectl delete upgrades.database.weaviate.io --all -n weaviate --ignore-not-found --timeout=120s || true
+
+    cat <<EOF > "$UPGRADE_CR_FILE"
+apiVersion: database.weaviate.io/v1alpha1
+kind: Upgrade
+metadata:
+  name: ${upgrade_name}
+  namespace: weaviate
+spec:
+  weaviateName: weaviate
+  versions:
+    - "${WEAVIATE_VERSION}"
+  skipBackups: ${skip_backups}
+${backend_line}
+EOF
+
+    echo_green "upgrade # Applying Upgrade CR: \n$(cat "$UPGRADE_CR_FILE")"
+    local applied="false"
+    for _ in {1..30}; do
+        if kubectl apply -f "$UPGRADE_CR_FILE"; then
+            applied="true"
+            break
+        fi
+        echo_yellow "Failed to apply Upgrade CR (operator webhook warming up?), retrying in 5s..."
         sleep 5
     done
-    echo_red "Operator did not update the StatefulSet to ${expected_image} in time"
+    if [[ "$applied" != "true" ]]; then
+        echo_red "Could not apply the Upgrade CR"
+        log_operator_debug_info
+        exit 1
+    fi
+
+    wait_for_upgrade_cr_complete "$upgrade_name"
+}
+
+# Polls an Upgrade resource until it reaches a terminal phase. Returns on
+# Success; aborts (with the operator debug dump) on Failed/Cancelled or timeout.
+# The timeout scales with REPLICAS since the controller rolls pods one version
+# at a time and waits for each to be healthy.
+function wait_for_upgrade_cr_complete() {
+    local name="$1"
+    local timeout=$((600 + REPLICAS * 120))
+    local waited=0
+    echo_green "upgrade # Waiting (timeout=${timeout}s) for Upgrade ${name} to complete"
+    while [[ "$waited" -lt "$timeout" ]]; do
+        local phase
+        phase=$(kubectl get upgrade "$name" -n weaviate -o jsonpath='{.status.phase}' 2>/dev/null || true)
+        case "$phase" in
+            Success)
+                echo_green "upgrade # Upgrade ${name} completed (phase=Success)"
+                return 0
+                ;;
+            Failed|Cancelled)
+                local err
+                err=$(kubectl get upgrade "$name" -n weaviate -o jsonpath='{.status.error}' 2>/dev/null || true)
+                echo_red "upgrade # Upgrade ${name} ended in phase=${phase}: ${err:-<no message>}"
+                log_operator_debug_info
+                exit 1
+                ;;
+            *)
+                echo_yellow "upgrade # Upgrade ${name} phase=${phase:-<pending>} (${waited}s/${timeout}s)"
+                ;;
+        esac
+        sleep 10
+        waited=$((waited + 10))
+    done
+    echo_red "upgrade # Upgrade ${name} did not complete within ${timeout}s"
     log_operator_debug_info
     exit 1
 }
@@ -397,6 +479,8 @@ function log_operator_debug_info() {
     echo_yellow "---------- wcs-weaviate-operator debug dump ----------"
     echo_yellow "[CR] weaviate/weaviate:"
     kubectl get weaviate weaviate -n weaviate -o yaml 2>/dev/null || echo_yellow "Weaviate CR not found"
+    echo_yellow "[Upgrade] upgrades.database.weaviate.io:"
+    kubectl get upgrades.database.weaviate.io -n weaviate -o yaml 2>/dev/null || true
     echo_yellow "[Operator] deployment + pods:"
     kubectl get deployment,pods -n "$OPERATOR_NAMESPACE" -o wide 2>/dev/null || true
     echo_yellow "[Operator] last logs:"

--- a/utilities/operator.sh
+++ b/utilities/operator.sh
@@ -1,0 +1,334 @@
+# Helper functions for deploying Weaviate through the wcs-weaviate-operator
+# (https://github.com/weaviate/wcs-weaviate-operator) instead of weaviate-helm.
+# Sourced by local-k8s.sh. Active only when DEPLOYMENT_METHOD=operator.
+#
+# The operator install manifest (dist/install.yaml) ships CRDs, RBAC, the
+# controller Deployment and cert-manager Certificate/Issuer resources. Its
+# admission webhooks use failurePolicy=Fail, so cert-manager must be running
+# before the operator and the Weaviate CR can be applied.
+
+OPERATOR_NAMESPACE="wcs-weaviate-operator-system"
+OPERATOR_DEPLOYMENT="wcs-weaviate-operator-controller-manager"
+WEAVIATE_CR_FILE="/tmp/weaviate-cr.yaml"
+MINIO_SECRET_NAME="minio-credentials"
+
+# Fail fast on configurations the operator cannot express. Everything listed
+# here is weaviate-helm specific (chart values, helm-only modules) or
+# contradicts how the operator manages the StatefulSet.
+function validate_operator_config() {
+    local unsupported=""
+    if [[ -n "$HELM_BRANCH" ]]; then unsupported="${unsupported} HELM_BRANCH"; fi
+    if [[ -n "$VALUES_INLINE" ]]; then unsupported="${unsupported} VALUES_INLINE"; fi
+    if [[ -n "$AUTH_CONFIG" ]]; then unsupported="${unsupported} AUTH_CONFIG"; fi
+    if [[ "$MCP" == "true" ]]; then unsupported="${unsupported} MCP"; fi
+    if [[ "$S3_OFFLOAD" == "true" ]]; then unsupported="${unsupported} S3_OFFLOAD"; fi
+    if [[ "$COLLECTION_EXPORT" == "true" ]]; then unsupported="${unsupported} COLLECTION_EXPORT"; fi
+    if [[ "$DELETE_STS" == "true" ]]; then unsupported="${unsupported} DELETE_STS"; fi
+    # A leftover values-override.yaml (helm-only, often a personal local file)
+    # should not block the operator path; it is simply not used.
+    if [ -f "${CURRENT_DIR}/values-override.yaml" ]; then
+        echo_yellow "values-override.yaml is helm-only and will be IGNORED with DEPLOYMENT_METHOD=operator (use cr-override.yaml instead)"
+    fi
+
+    if [[ -n "$unsupported" ]]; then
+        echo_red "DEPLOYMENT_METHOD=operator is incompatible with:${unsupported}"
+        echo_red "These options are specific to the weaviate-helm deployment method."
+        echo_red "Use cr-override.yaml to customize the Weaviate CR instead of helm values."
+        exit 1
+    fi
+
+    # The operator's validating webhook only accepts 1 (single node) or an
+    # odd number >= 3 of replicas (raft quorum). Catch it before creating
+    # the Kind cluster so misconfigurations fail in seconds, not minutes.
+    if [[ "$REPLICAS" -ne 1 ]] && { [[ "$REPLICAS" -lt 3 ]] || [[ $((REPLICAS % 2)) -eq 0 ]]; }; then
+        echo_red "DEPLOYMENT_METHOD=operator requires REPLICAS to be 1 or an odd number >= 3 (raft quorum). Got: $REPLICAS"
+        exit 1
+    fi
+
+    # Extra tools only required by the operator path
+    local operator_requirements=("git" "docker" "yq")
+    for requirement in "${operator_requirements[@]}"; do
+        if ! command -v "$requirement" &> /dev/null; then
+            echo_red "Please install '$requirement' before running with DEPLOYMENT_METHOD=operator"
+            exit 1
+        fi
+    done
+
+    if [[ -n "$MODULES" ]]; then
+        echo_yellow "DEPLOYMENT_METHOD=operator: MODULES are passed to the Weaviate CR (spec.modules.extra),"
+        echo_yellow "but the operator does not deploy module inference sidecars (contextionary, transformers, ...)."
+        echo_yellow "Modules requiring a companion deployment will not be functional."
+    fi
+}
+
+function setup_cert_manager() {
+    echo_green "*** cert-manager ${CERT_MANAGER_VERSION} (required by operator admission webhooks) ***"
+    kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+    kubectl wait --for=condition=available \
+        deployment/cert-manager deployment/cert-manager-cainjector deployment/cert-manager-webhook \
+        -n cert-manager --timeout=240s
+}
+
+# Resolves the operator sources and image, loads the image into Kind and
+# installs the operator. Source/image resolution:
+#   OPERATOR_DIR    -> use an existing local checkout (PR testing from the
+#                      wcs-weaviate-operator repo itself)
+#   OPERATOR_BRANCH -> clone that branch of weaviate/wcs-weaviate-operator
+#   OPERATOR_IMAGE  -> use this controller image instead of building one from
+#                      the sources; if present in the local Docker daemon it
+#                      is kind-loaded, otherwise the cluster will pull it
+function setup_operator() {
+    local src_dir
+    if [[ -n "$OPERATOR_DIR" ]]; then
+        src_dir="$OPERATOR_DIR"
+        if [ ! -f "${src_dir}/dist/install.yaml" ]; then
+            echo_red "OPERATOR_DIR=${src_dir} does not look like a wcs-weaviate-operator checkout (missing dist/install.yaml)"
+            exit 1
+        fi
+        echo_green "Using local wcs-weaviate-operator checkout: ${src_dir}"
+    else
+        src_dir="/tmp/wcs-weaviate-operator"
+        rm -rf "$src_dir"
+        # weaviate/wcs-weaviate-operator is a private repository. For HTTPS
+        # clones a token can be supplied via GH_TOKEN/GITHUB_TOKEN; local
+        # users can also point OPERATOR_REPO at an SSH remote.
+        local clone_url="$OPERATOR_REPO"
+        local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+        if [[ -n "$token" ]] && [[ "$clone_url" == https://github.com/* ]]; then
+            clone_url="https://x-access-token:${token}@github.com/${clone_url#https://github.com/}"
+        fi
+        echo_green "Cloning wcs-weaviate-operator (branch: ${OPERATOR_BRANCH})"
+        if ! git clone -b "$OPERATOR_BRANCH" --depth 1 "$clone_url" "$src_dir"; then
+            echo_red "Could not clone ${OPERATOR_REPO} (branch: ${OPERATOR_BRANCH})."
+            echo_red "The repository is private: provide a token via GH_TOKEN/GITHUB_TOKEN,"
+            echo_red "set OPERATOR_REPO to an SSH remote, or point OPERATOR_DIR at a local checkout."
+            exit 1
+        fi
+    fi
+
+    local operator_image="$OPERATOR_IMAGE"
+    if [[ -z "$operator_image" ]]; then
+        operator_image="wcs-weaviate-operator:local"
+        echo_green "Building operator image ${operator_image} from ${src_dir}"
+        # BuildKit is required: the operator's .dockerignore uses an
+        # exclude-all + '!**/*.go' re-include pattern that the legacy builder
+        # resolves incorrectly (the Go sources never reach the build context).
+        # --load is required for buildx container drivers, where the result
+        # would otherwise stay in the build cache and never reach the local
+        # Docker daemon (and therefore 'kind load' would fail).
+        DOCKER_BUILDKIT=1 docker build --load --build-arg VERSION=local -t "$operator_image" "$src_dir"
+        kind load docker-image "$operator_image" --name weaviate-k8s
+    elif docker image inspect "$operator_image" &> /dev/null; then
+        echo_green "Loading local operator image ${operator_image} into Kind"
+        kind load docker-image "$operator_image" --name weaviate-k8s
+    else
+        echo_yellow "Operator image ${operator_image} not found locally; the cluster will pull it"
+    fi
+
+    # Render the install manifest with the resolved controller image. The
+    # manifest ships with the kustomize placeholder 'controller:latest'.
+    local manifest="/tmp/wcs-weaviate-operator-install.yaml"
+    sed "s|image: controller:latest|image: ${operator_image}|" "${src_dir}/dist/install.yaml" > "$manifest"
+
+    # The manifest contains a ServiceMonitor for the controller. Without the
+    # prometheus-operator CRDs (OBSERVABILITY=false) applying it would fail.
+    if ! kubectl get crd servicemonitors.monitoring.coreos.com &> /dev/null; then
+        echo_yellow "ServiceMonitor CRD not present; stripping operator ServiceMonitor from install manifest"
+        yq -i 'select(.kind == "ServiceMonitor" | not)' "$manifest"
+    fi
+
+    echo_green "*** wcs-weaviate-operator (image: ${operator_image}) ***"
+    # Retry: the Certificate/Issuer resources need the cert-manager webhook,
+    # which may still be warming up right after setup_cert_manager.
+    local applied="false"
+    for _ in {1..10}; do
+        if kubectl apply --server-side -f "$manifest"; then
+            applied="true"
+            break
+        fi
+        echo_yellow "Failed to apply operator manifest (cert-manager webhook warming up?), retrying in 10s..."
+        sleep 10
+    done
+    if [[ "$applied" != "true" ]]; then
+        echo_red "Could not install wcs-weaviate-operator"
+        exit 1
+    fi
+
+    kubectl wait --for=condition=available "deployment/${OPERATOR_DEPLOYMENT}" \
+        -n "$OPERATOR_NAMESPACE" --timeout=300s
+    echo_green "wcs-weaviate-operator is running"
+}
+
+# MinIO credentials consumed by spec.cloudAuth.aws.credentials. Values match
+# the static credentials of manifests/minio-dev.yaml.
+function create_minio_credentials_secret() {
+    kubectl create secret generic "$MINIO_SECRET_NAME" -n weaviate \
+        --from-literal=access-key=aws_access_key \
+        --from-literal=secret-key=aws_secret_key \
+        --dry-run=client -o yaml | kubectl apply -f -
+}
+
+function add_minio_cloud_auth_to_cr() {
+    yq -i '.spec.cloudAuth.aws.region = "us-east-1" |
+           .spec.cloudAuth.aws.endpoint = "minio:9000" |
+           .spec.cloudAuth.aws.credentials.accessKeyId = {"name": "'"$MINIO_SECRET_NAME"'", "key": "access-key"} |
+           .spec.cloudAuth.aws.credentials.secretAccessKey = {"name": "'"$MINIO_SECRET_NAME"'", "key": "secret-key"}' \
+        "$WEAVIATE_CR_FILE"
+}
+
+# Translates the script's env vars into a Weaviate CR. The CR is named
+# 'weaviate' on purpose: the operator then creates sts/weaviate, svc/weaviate
+# and svc/weaviate-grpc — the same resource names the helm chart produces —
+# so all health checks and port-forwarding helpers work for both methods.
+#
+# Notes on auth: the operator unconditionally enables API key authentication
+# with a generated admin key (secret weaviate-operator-admin-key). Anonymous
+# access is enabled here unless RBAC is requested, mirroring the helm chart
+# defaults. get_bearer_token() in helpers.sh knows how to fetch the generated
+# key from the secret.
+function generate_weaviate_cr() {
+    local anonymous_access="true"
+    if [[ "$RBAC" == "true" ]]; then
+        anonymous_access="false"
+    fi
+
+    cat <<EOF > "$WEAVIATE_CR_FILE"
+apiVersion: database.weaviate.io/v1alpha1
+kind: Weaviate
+metadata:
+  name: weaviate
+  namespace: weaviate
+spec:
+  version: "${WEAVIATE_VERSION}"
+  replicas: ${REPLICAS}
+  istioEnabled: false
+  debug: ${DEBUG}
+  image:
+    repository: "${WEAVIATE_IMAGE_PREFIX}/weaviate"
+  authentication:
+    anonymousAccess: ${anonymous_access}
+  podConfig:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 300Mi
+    storage:
+      size: ${WEAVIATE_STORAGE_SIZE}
+    extraEnv:
+      - name: DISABLE_RECOVERY_ON_PANIC
+        value: "true"
+  config:
+    disableTelemetry: true
+    raft:
+      bootstrapTimeout: "3600"
+EOF
+
+    if [[ "$RBAC" == "true" ]]; then
+        yq -i '.spec.authorization.rbac.enabled = true' "$WEAVIATE_CR_FILE"
+    fi
+
+    if [[ "$OIDC" == "true" ]]; then
+        yq -i '.spec.authentication.oidc = {
+                  "enabled": true,
+                  "issuer": "http://'"${KEYCLOAK_HOST}"':9090/realms/weaviate",
+                  "usernameClaim": "email",
+                  "groupsClaim": "groups",
+                  "clientId": "demo",
+                  "skipClientIdCheck": false
+               }' "$WEAVIATE_CR_FILE"
+    fi
+
+    if [[ "$DYNAMIC_USERS" == "true" ]]; then
+        yq -i '.spec.podConfig.extraEnv += [{"name": "AUTHENTICATION_DB_USERS_ENABLED", "value": "true"}]' "$WEAVIATE_CR_FILE"
+    fi
+
+    if [[ "$ENABLE_BACKUP" == "true" ]]; then
+        yq -i '.spec.backup.s3 = {"bucket": "weaviate-backups", "useSSL": false}' "$WEAVIATE_CR_FILE"
+        add_minio_cloud_auth_to_cr
+    fi
+
+    if [[ "$USAGE_S3" == "true" ]]; then
+        yq -i '.spec.usage.s3 = {"bucket": "weaviate-usage", "prefix": "billing"} |
+               .spec.usage.scrapeInterval = "10s"' "$WEAVIATE_CR_FILE"
+        add_minio_cloud_auth_to_cr
+    fi
+
+    if [[ -n "$MODULES" ]]; then
+        IFS=',' read -ra CR_MODULES <<< "$MODULES"
+        for MODULE in "${CR_MODULES[@]}"; do
+            yq -i '.spec.modules.extra += ["'"$MODULE"'"]' "$WEAVIATE_CR_FILE"
+        done
+    fi
+
+    # cr-override.yaml is the operator-mode counterpart of values-override.yaml:
+    # a partial Weaviate CR deep-merged on top of the generated one (maps are
+    # merged, arrays appended).
+    if [ -f "${CURRENT_DIR}/cr-override.yaml" ]; then
+        echo_green "Merging cr-override.yaml into the generated Weaviate CR"
+        yq eval-all -i 'select(fileIndex == 0) *+ select(fileIndex == 1)' \
+            "$WEAVIATE_CR_FILE" "${CURRENT_DIR}/cr-override.yaml"
+    fi
+}
+
+# Applies the Weaviate CR with retries: right after the operator deployment
+# turns available its webhook endpoints may still refuse connections for a
+# few seconds, and the CA bundle injection may lag.
+function deploy_weaviate_cr() {
+    echo_green "Applying Weaviate CR: \n$(cat "$WEAVIATE_CR_FILE")"
+    local applied="false"
+    for _ in {1..30}; do
+        if kubectl apply -f "$WEAVIATE_CR_FILE"; then
+            applied="true"
+            break
+        fi
+        echo_yellow "Failed to apply Weaviate CR (operator webhook warming up?), retrying in 5s..."
+        sleep 5
+    done
+    if [[ "$applied" != "true" ]]; then
+        echo_red "Could not apply the Weaviate CR"
+        log_operator_debug_info
+        exit 1
+    fi
+}
+
+# After an upgrade the operator has to reconcile the CR change into the
+# StatefulSet before 'kubectl rollout status' means anything. Wait until the
+# StatefulSet pod template references the expected weaviate image.
+function wait_for_operator_sts_image() {
+    local expected_image="${WEAVIATE_IMAGE_PREFIX}/weaviate:${WEAVIATE_VERSION}"
+    echo_green "Waiting for operator to roll StatefulSet to image ${expected_image}"
+    for _ in {1..60}; do
+        local current_image
+        current_image=$(kubectl get sts weaviate -n weaviate -o jsonpath='{.spec.template.spec.containers[?(@.name=="weaviate")].image}' 2>/dev/null || true)
+        if [[ "$current_image" == "$expected_image" ]]; then
+            echo_green "StatefulSet template updated to ${expected_image}"
+            return
+        fi
+        echo_yellow "StatefulSet image is '${current_image:-<none>}', waiting for operator reconcile..."
+        sleep 5
+    done
+    echo_red "Operator did not update the StatefulSet to ${expected_image} in time"
+    log_operator_debug_info
+    exit 1
+}
+
+function wait_for_weaviate_cr_ready() {
+    local timeout=$1
+    echo_green "Waiting (timeout=${timeout}) for Weaviate CR to report Ready"
+    if ! kubectl wait weaviate/weaviate -n weaviate --for=condition=Ready --timeout="$timeout"; then
+        echo_red "Weaviate CR did not become Ready"
+        log_operator_debug_info
+        exit 1
+    fi
+}
+
+function log_operator_debug_info() {
+    echo_yellow "---------- wcs-weaviate-operator debug dump ----------"
+    echo_yellow "[CR] weaviate/weaviate:"
+    kubectl get weaviate weaviate -n weaviate -o yaml 2>/dev/null || echo_yellow "Weaviate CR not found"
+    echo_yellow "[Operator] deployment + pods:"
+    kubectl get deployment,pods -n "$OPERATOR_NAMESPACE" -o wide 2>/dev/null || true
+    echo_yellow "[Operator] last logs:"
+    kubectl logs -n "$OPERATOR_NAMESPACE" "deployment/${OPERATOR_DEPLOYMENT}" --tail=100 2>/dev/null || true
+    echo_yellow "------------------------------------------------------"
+}

--- a/utilities/operator.sh
+++ b/utilities/operator.sh
@@ -55,10 +55,51 @@ function validate_operator_config() {
     done
 
     if [[ -n "$MODULES" ]]; then
-        echo_yellow "DEPLOYMENT_METHOD=operator: MODULES are passed to the Weaviate CR (spec.modules.extra),"
-        echo_yellow "but the operator does not deploy module inference sidecars (contextionary, transformers, ...)."
-        echo_yellow "Modules requiring a companion deployment will not be functional."
+        # MODULES are passed to the Weaviate CR (spec.modules.extra). The
+        # operator only configures Weaviate to use a module, it does not deploy
+        # the companion inference server. We deploy the inference services for
+        # text2vec-transformers and text2vec-model2vec ourselves (see
+        # deploy_operator_module_services); any other module that needs a
+        # companion deployment will be enabled in the CR but not functional.
+        IFS=',' read -ra VALIDATE_MODULES <<< "$MODULES"
+        local modules_without_inference=""
+        for MODULE in "${VALIDATE_MODULES[@]}"; do
+            case "$MODULE" in
+                "text2vec-transformers"|"text2vec-model2vec") ;;
+                *) modules_without_inference="${modules_without_inference} ${MODULE}" ;;
+            esac
+        done
+        if [[ -n "$modules_without_inference" ]]; then
+            echo_yellow "DEPLOYMENT_METHOD=operator deploys an inference service only for text2vec-transformers and text2vec-model2vec."
+            echo_yellow "These MODULES have no companion inference deployment and may not be functional:${modules_without_inference}"
+        fi
     fi
+}
+
+# In operator mode the operator does not deploy module inference servers, so we
+# apply the same Deployment + Service that weaviate-helm would create. Only the
+# locally-runnable vectorizers are covered (text2vec-transformers,
+# text2vec-model2vec); their manifests live in manifests/ and are namespaced to
+# 'weaviate', so clean() removes them together with the namespace. Idempotent
+# (kubectl apply), so it is safe to call again on upgrade.
+function deploy_operator_module_services() {
+    [[ -z "$MODULES" ]] && return 0
+    IFS=',' read -ra SERVICE_MODULES <<< "$MODULES"
+    for MODULE in "${SERVICE_MODULES[@]}"; do
+        case "$MODULE" in
+            "text2vec-transformers")
+                echo_green "Deploying transformers-inference service (operator mode)"
+                kubectl apply -f "${CURRENT_DIR}/manifests/transformers-inference.yaml"
+                ;;
+            "text2vec-model2vec")
+                echo_green "Deploying model2vec-inference service (operator mode)"
+                kubectl apply -f "${CURRENT_DIR}/manifests/model2vec-inference.yaml"
+                ;;
+            *)
+                : # No operator-managed inference deployment for this module.
+                ;;
+        esac
+    done
 }
 
 function setup_cert_manager() {
@@ -275,6 +316,18 @@ EOF
         IFS=',' read -ra CR_MODULES <<< "$MODULES"
         for MODULE in "${CR_MODULES[@]}"; do
             yq -i '.spec.modules.extra += ["'"$MODULE"'"]' "$WEAVIATE_CR_FILE"
+            # Point Weaviate at the in-cluster inference service we deploy in
+            # operator mode (deploy_operator_module_services). The helm chart
+            # wires the same env vars to the same service DNS names. The service
+            # is in the 'weaviate' namespace, so the short name resolves.
+            case "$MODULE" in
+                "text2vec-transformers")
+                    yq -i '.spec.podConfig.extraEnv += [{"name": "TRANSFORMERS_INFERENCE_API", "value": "http://transformers-inference:8080"}]' "$WEAVIATE_CR_FILE"
+                    ;;
+                "text2vec-model2vec")
+                    yq -i '.spec.podConfig.extraEnv += [{"name": "MODEL2VEC_INFERENCE_API", "value": "http://model2vec-inference:8080"}]' "$WEAVIATE_CR_FILE"
+                    ;;
+            esac
         done
     fi
 

--- a/utilities/operator.sh
+++ b/utilities/operator.sh
@@ -92,13 +92,29 @@ function setup_operator() {
         # weaviate/wcs-weaviate-operator is a private repository. For HTTPS
         # clones a token can be supplied via GH_TOKEN/GITHUB_TOKEN; local
         # users can also point OPERATOR_REPO at an SSH remote.
-        local clone_url="$OPERATOR_REPO"
         local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
-        if [[ -n "$token" ]] && [[ "$clone_url" == https://github.com/* ]]; then
-            clone_url="https://x-access-token:${token}@github.com/${clone_url#https://github.com/}"
-        fi
         echo_green "Cloning wcs-weaviate-operator (branch: ${OPERATOR_BRANCH})"
-        if ! git clone -b "$OPERATOR_BRANCH" --depth 1 "$clone_url" "$src_dir"; then
+        local clone_rc=0
+        if [[ -n "$token" ]] && [[ "$OPERATOR_REPO" == https://github.com/* ]]; then
+            # Authenticate via GIT_ASKPASS so the token never lands on the
+            # command line (where 'ps' or shell history could capture it).
+            # GIT_ASKPASS is non-interactive: git runs the helper to read the
+            # credential, and the helper only echoes an env var, so nothing
+            # secret is written to disk either. The 'x-access-token' username is
+            # not sensitive. GIT_TERMINAL_PROMPT=0 keeps it fully automated
+            # (fail fast instead of hanging on a tty prompt).
+            local askpass
+            askpass="$(mktemp)"
+            printf '#!/bin/sh\nexec echo "$GIT_ASKPASS_TOKEN"\n' > "$askpass"
+            chmod +x "$askpass"
+            local auth_url="https://x-access-token@github.com/${OPERATOR_REPO#https://github.com/}"
+            GIT_ASKPASS_TOKEN="$token" GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 \
+                git clone -b "$OPERATOR_BRANCH" --depth 1 "$auth_url" "$src_dir" || clone_rc=$?
+            rm -f "$askpass"
+        else
+            git clone -b "$OPERATOR_BRANCH" --depth 1 "$OPERATOR_REPO" "$src_dir" || clone_rc=$?
+        fi
+        if [[ "$clone_rc" -ne 0 ]]; then
             echo_red "Could not clone ${OPERATOR_REPO} (branch: ${OPERATOR_BRANCH})."
             echo_red "The repository is private: provide a token via GH_TOKEN/GITHUB_TOKEN,"
             echo_red "set OPERATOR_REPO to an SSH remote, or point OPERATOR_DIR at a local checkout."
@@ -110,13 +126,15 @@ function setup_operator() {
     if [[ -z "$operator_image" ]]; then
         operator_image="wcs-weaviate-operator:local"
         echo_green "Building operator image ${operator_image} from ${src_dir}"
-        # BuildKit is required: the operator's .dockerignore uses an
-        # exclude-all + '!**/*.go' re-include pattern that the legacy builder
-        # resolves incorrectly (the Go sources never reach the build context).
-        # --load is required for buildx container drivers, where the result
-        # would otherwise stay in the build cache and never reach the local
-        # Docker daemon (and therefore 'kind load' would fail).
-        DOCKER_BUILDKIT=1 docker build --load --build-arg VERSION=local -t "$operator_image" "$src_dir"
+        # Use 'docker buildx build' (BuildKit): the operator's .dockerignore
+        # uses an exclude-all + '!**/*.go' re-include pattern that the legacy
+        # builder resolves incorrectly (the Go sources never reach the build
+        # context). '--load' exports the result into the local Docker daemon —
+        # with a buildx container driver it would otherwise stay in the build
+        # cache and 'kind load' would fail. '--load' is a buildx-only flag, so
+        # we invoke buildx explicitly instead of relying on 'docker build'
+        # being aliased to buildx (which is not the case on plain Docker/CI).
+        docker buildx build --load --build-arg VERSION=local -t "$operator_image" "$src_dir"
         kind load docker-image "$operator_image" --name weaviate-k8s
     elif docker image inspect "$operator_image" &> /dev/null; then
         echo_green "Loading local operator image ${operator_image} into Kind"


### PR DESCRIPTION
## Motivation

WCS is moving toward operating Weaviate clusters through the [wcs-weaviate-operator](https://github.com/weaviate/wcs-weaviate-operator), but all local/CI tooling in this repo only knows how to deploy via the weaviate-helm chart. This PR adds `DEPLOYMENT_METHOD=operator` so the same tool (and the same GitHub Action) can spin up operator-managed clusters — for local development against the operator, for reproducing operator-specific bugs, and so the operator repo's own PR CI can reuse this action with a pre-built controller image.

## Approach

The operator path is an alternative, not a layer on top of helm: the two methods are mutually exclusive and the default (`helm`) path is behaviorally unchanged — `setup`/`upgrade` branch into either helm or operator logic, with all operator code isolated in a new `utilities/operator.sh`.

Key design decisions:

- **Same resource names as the chart.** The generated Weaviate CR is named `weaviate`, so the operator produces `sts/weaviate`, `svc/weaviate`, `svc/weaviate-grpc` — letting every existing health-check, port-forwarding, and pod-logging helper work unmodified for both methods. This is what keeps the diff in `local-k8s.sh` small.
- **Three operator source modes** to cover all consumers: `OPERATOR_BRANCH` (clone + docker build, default `main`), `OPERATOR_IMAGE` (pre-built image, kind-loaded if present locally — used by operator-repo PR CI), and `OPERATOR_DIR` (local checkout, no clone). The repo is private, so HTTPS clones honor `GH_TOKEN`/`GITHUB_TOKEN`, and `OPERATOR_REPO` allows SSH remotes for local users.
- **Fail fast on what the operator can't express.** Helm-only options (`HELM_BRANCH`, `VALUES_INLINE`, `AUTH_CONFIG`, `DELETE_STS`, `MCP`, `S3_OFFLOAD`, `COLLECTION_EXPORT`) error out immediately, and the operator webhook's replica rule (1 or odd >= 3) is validated *before* the Kind cluster is created, so misconfigurations fail in seconds rather than after minutes of cluster setup.
- **`cr-override.yaml` replaces `values-override.yaml`** as the customization escape hatch in operator mode: a partial CR deep-merged (via `yq`) onto the generated one. A leftover `values-override.yaml` is ignored with a warning rather than erroring, since it's often a personal local file.
- **Upgrades wait for reconciliation.** `upgrade` re-applies the CR and explicitly waits for the StatefulSet pod template to reference the new image before watching rollout status — otherwise `kubectl rollout status` would report success against the *old* template while the operator is still reconciling.

Feature parity in operator mode: RBAC, OIDC (Keycloak), dynamic users, S3 backup and usage (MinIO via `spec.cloudAuth.aws`), observability, `EXPOSE_PODS`, and `--local-images`.

## Key areas for review

- `utilities/operator.sh` — all new logic. Worth a careful read of `generate_weaviate_cr()` (env-var → CR translation, auth semantics: the operator always enables API-key auth with a generated admin key; anonymous access mirrors helm-chart defaults unless RBAC is on) and the webhook warm-up retry loops in `setup_operator()`/`deploy_weaviate_cr()`.
- `local-k8s.sh` — verify the helm branch of `setup`/`upgrade` is a pure move (indentation change), not a behavior change. The `clean` path now deletes the CR before the namespace so the operator can tear down its resources.
- `utilities/helpers.sh:get_bearer_token` — new `secretKeyRef` resolution for the operator-generated admin key, inserted between the existing literal-env and configmap fallbacks. Check it can't break helm-mode token resolution (in helm mode the jsonpath yields empty and falls through).
- `.github/workflows/main.yml` — the `WCS_OPERATOR_PAT` gating pattern: a `check-operator-token` job lets all operator jobs skip cleanly (not fail) while the secret is unconfigured, including on forks.

## Risks and mitigations

- **Regression in the default helm path**: mitigated by strictly branching — operator logic only runs when `DEPLOYMENT_METHOD=operator`, and the entire pre-existing CI matrix (helm-based) still runs unchanged on this PR. Also verified locally: helm-path smoke deploy after the change is green.
- **Webhook race conditions** (cert-manager CA injection and the operator's admission webhook are not instantly ready after their Deployments turn available): both the operator manifest apply and the CR apply retry with backoff; failures dump operator logs + CR state via `log_operator_debug_info` for triage.
- **Private-repo token handling**: the token is only ever interpolated into the in-memory clone URL (never written to disk); in CI, GitHub masks the secret in logs. SSH remotes via `OPERATOR_REPO` avoid tokens entirely for local use.
- **Operator image build flakiness**: the operator's allowlist-style `.dockerignore` is mishandled by the legacy Docker builder, and buildx container drivers don't expose images to the daemon by default — the build forces `DOCKER_BUILDKIT=1 --load` to avoid both failure modes (documented inline).
- **CI cost while the secret is missing**: all operator jobs except the helm-incompatibility guard skip until `WCS_OPERATOR_PAT` (read access to the private operator repo) is configured, so the new matrix adds no noise in the meantime.

## Testing

Verified locally end-to-end (Kind on macOS/arm64): operator setup with a local checkout (`OPERATOR_DIR`) on 1.36.8 → CR `Ready`, anonymous + admin-key API access, per-pod forwarding and metrics green; CR-driven upgrade to 1.37.0 with raft in sync; `clean`; and a helm-path regression smoke.

New CI jobs in `.github/workflows/main.yml`:

- **Basic operator deployment** (3 replicas) and a **feature matrix** (single node) covering RBAC, OIDC, dynamic users, backup, usage-S3, and observability in operator mode
- **CR-driven upgrade**: deploy 1.36.0 via the operator, upgrade to latest, verify the operator rolls the StatefulSet
- **Pre-built image flow**: builds the controller image first, then deploys with `operator-image` + `operator-dir` — mirroring exactly how the operator repo's PR CI will consume this action
- **Incompatibility guard**: asserts helm-only options fail fast in operator mode (runs without the secret)

Known limitation, surfaced as a warning at validation time: `MODULES` are passed to the CR (`spec.modules.extra`), but the operator does not deploy module inference sidecars (contextionary, transformers, ...), so modules needing a companion deployment won't be functional in operator mode.

## Breaking changes

None. `DEPLOYMENT_METHOD` defaults to `helm`; all new env vars and action inputs (`deployment-method`, `operator-branch`, `operator-image`, `operator-dir`, `github-token`) are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
